### PR TITLE
Add CI/CD release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   build-and-release:
     name: Build, Sign, Notarize & Release
-    runs-on: skyfall
+    runs-on: busylight
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
 
       - name: Build archive
         run: |
+          set -o pipefail
           ARCHIVE_PATH="$RUNNER_TEMP/BusyLight.xcarchive"
           xcodebuild archive \
             -project "$PROJECT" \
@@ -96,27 +97,14 @@ jobs:
 
       - name: Export archive
         run: |
+          set -o pipefail
           EXPORT_PATH="$RUNNER_TEMP/export"
 
           # Create export options plist
-          cat > "$RUNNER_TEMP/ExportOptions.plist" << 'PLIST'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-              <key>method</key>
-              <string>developer-id</string>
-              <key>teamID</key>
-          PLIST
-          echo "    <string>${{ secrets.APPLE_TEAM_ID }}</string>" >> "$RUNNER_TEMP/ExportOptions.plist"
-          cat >> "$RUNNER_TEMP/ExportOptions.plist" << 'PLIST'
-              <key>signingStyle</key>
-              <string>manual</string>
-              <key>signingCertificate</key>
-              <string>Developer ID Application</string>
-          </dict>
-          </plist>
-          PLIST
+          /usr/libexec/PlistBuddy -c "Add :method string developer-id" "$RUNNER_TEMP/ExportOptions.plist"
+          /usr/libexec/PlistBuddy -c "Add :teamID string ${{ secrets.APPLE_TEAM_ID }}" "$RUNNER_TEMP/ExportOptions.plist"
+          /usr/libexec/PlistBuddy -c "Add :signingStyle string manual" "$RUNNER_TEMP/ExportOptions.plist"
+          /usr/libexec/PlistBuddy -c "Add :signingCertificate string Developer ID Application" "$RUNNER_TEMP/ExportOptions.plist"
 
           xcodebuild -exportArchive \
             -archivePath "$ARCHIVE_PATH" \
@@ -124,6 +112,11 @@ jobs:
             -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist" \
             | xcpretty
 
+          # Find the exported app
+          echo "Export contents:"
+          ls -la "$EXPORT_PATH"
+          APP_PATH=$(find "$EXPORT_PATH" -name "*.app" -maxdepth 1 | head -1)
+          echo "APP_PATH=$APP_PATH" >> "$GITHUB_ENV"
           echo "EXPORT_PATH=$EXPORT_PATH" >> "$GITHUB_ENV"
 
       - name: Notarize app
@@ -132,8 +125,6 @@ jobs:
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          APP_PATH="$EXPORT_PATH/$PRODUCT_NAME.app"
-
           # Create a zip for notarization
           ditto -c -k --keepParent "$APP_PATH" "$RUNNER_TEMP/app.zip"
 
@@ -152,7 +143,8 @@ jobs:
       - name: Create DMG
         run: |
           DMG_PATH="$RUNNER_TEMP/BusyLight-${{ steps.version.outputs.version }}.dmg"
-          APP_PATH="$EXPORT_PATH/$PRODUCT_NAME.app"
+
+          APP_NAME=$(basename "$APP_PATH")
 
           create-dmg \
             --volname "$PRODUCT_NAME" \
@@ -160,8 +152,8 @@ jobs:
             --window-pos 200 120 \
             --window-size 600 400 \
             --icon-size 100 \
-            --icon "$PRODUCT_NAME.app" 150 190 \
-            --hide-extension "$PRODUCT_NAME.app" \
+            --icon "$APP_NAME" 150 190 \
+            --hide-extension "$APP_NAME" \
             --app-drop-link 450 190 \
             "$DMG_PATH" \
             "$APP_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,6 @@ jobs:
 
           create-dmg \
             --volname "$PRODUCT_NAME" \
-            --volicon "$APP_PATH/Contents/Resources/AppIcon.icns" \
             --window-pos 200 120 \
             --window-size 600 400 \
             --icon-size 100 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,16 @@ env:
   PRODUCT_NAME: "Busy Light"
   APP_BUNDLE_ID: com.mboszko.BusyLight
 
+permissions:
+  contents: write
+
 jobs:
   build-and-release:
     name: Build, Sign, Notarize & Release
     runs-on: macos-15
     timeout-minutes: 30
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   build-and-release:
     name: Build, Sign, Notarize & Release
-    runs-on: macos-15
+    runs-on: skyfall
     timeout-minutes: 30
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -147,14 +147,20 @@ jobs:
 
       - name: Create DMG volume icon
         run: |
-          # Convert PNG to icns for DMG volume icon
+          # Convert production PNG to icns for DMG volume icon
           ICONSET_PATH="$RUNNER_TEMP/VolumeIcon.iconset"
           mkdir -p "$ICONSET_PATH"
-          sips -z 512 512 ProductionAssets/AppIcon-iOS-Default-1024x1024@1x.png --out "$ICONSET_PATH/icon_256x256@2x.png"
-          sips -z 256 256 ProductionAssets/AppIcon-iOS-Default-1024x1024@1x.png --out "$ICONSET_PATH/icon_256x256.png"
-          sips -z 128 128 ProductionAssets/AppIcon-iOS-Default-1024x1024@1x.png --out "$ICONSET_PATH/icon_128x128.png"
-          sips -z 32 32 ProductionAssets/AppIcon-iOS-Default-1024x1024@1x.png --out "$ICONSET_PATH/icon_32x32.png"
-          sips -z 16 16 ProductionAssets/AppIcon-iOS-Default-1024x1024@1x.png --out "$ICONSET_PATH/icon_16x16.png"
+          SRC="ProductionAssets/AppIcon-iOS-Default-1024x1024@1x.png"
+          sips -z 1024 1024 "$SRC" --out "$ICONSET_PATH/icon_512x512@2x.png"
+          sips -z 512 512   "$SRC" --out "$ICONSET_PATH/icon_512x512.png"
+          sips -z 512 512   "$SRC" --out "$ICONSET_PATH/icon_256x256@2x.png"
+          sips -z 256 256   "$SRC" --out "$ICONSET_PATH/icon_256x256.png"
+          sips -z 256 256   "$SRC" --out "$ICONSET_PATH/icon_128x128@2x.png"
+          sips -z 128 128   "$SRC" --out "$ICONSET_PATH/icon_128x128.png"
+          sips -z 64 64     "$SRC" --out "$ICONSET_PATH/icon_32x32@2x.png"
+          sips -z 32 32     "$SRC" --out "$ICONSET_PATH/icon_32x32.png"
+          sips -z 32 32     "$SRC" --out "$ICONSET_PATH/icon_16x16@2x.png"
+          sips -z 16 16     "$SRC" --out "$ICONSET_PATH/icon_16x16.png"
           iconutil -c icns "$ICONSET_PATH" -o "$RUNNER_TEMP/VolumeIcon.icns"
 
       - name: Create DMG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,6 @@ jobs:
     name: Build, Sign, Notarize & Release
     runs-on: skyfall
     timeout-minutes: 30
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
     steps:
       - name: Checkout
@@ -44,7 +42,7 @@ jobs:
           echo "Version: $VERSION, Build: $BUILD_NUMBER"
 
       - name: Install tools
-        run: brew install xcodegen create-dmg
+        run: brew install create-dmg
 
       - name: Generate Xcode project
         run: xcodegen generate
@@ -84,7 +82,6 @@ jobs:
 
       - name: Build archive
         run: |
-          set -o pipefail
           ARCHIVE_PATH="$RUNNER_TEMP/BusyLight.xcarchive"
           xcodebuild archive \
             -project "$PROJECT" \
@@ -96,13 +93,11 @@ jobs:
             DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
             CODE_SIGN_IDENTITY="Developer ID Application" \
             CODE_SIGN_STYLE=Manual \
-            OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH" \
-            | xcpretty
+            OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH"
           echo "ARCHIVE_PATH=$ARCHIVE_PATH" >> "$GITHUB_ENV"
 
       - name: Export archive
         run: |
-          set -o pipefail
           EXPORT_PATH="$RUNNER_TEMP/export"
 
           # Create export options plist
@@ -114,8 +109,7 @@ jobs:
           xcodebuild -exportArchive \
             -archivePath "$ARCHIVE_PATH" \
             -exportPath "$EXPORT_PATH" \
-            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist" \
-            | xcpretty
+            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist"
 
           # Find the exported app
           echo "Export contents:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,18 @@ jobs:
 
           rm "$RUNNER_TEMP/app.zip"
 
+      - name: Create DMG volume icon
+        run: |
+          # Convert PNG to icns for DMG volume icon
+          ICONSET_PATH="$RUNNER_TEMP/VolumeIcon.iconset"
+          mkdir -p "$ICONSET_PATH"
+          sips -z 512 512 ProductionAssets/AppIcon-iOS-Default-1024x1024@1x.png --out "$ICONSET_PATH/icon_256x256@2x.png"
+          sips -z 256 256 ProductionAssets/AppIcon-iOS-Default-1024x1024@1x.png --out "$ICONSET_PATH/icon_256x256.png"
+          sips -z 128 128 ProductionAssets/AppIcon-iOS-Default-1024x1024@1x.png --out "$ICONSET_PATH/icon_128x128.png"
+          sips -z 32 32 ProductionAssets/AppIcon-iOS-Default-1024x1024@1x.png --out "$ICONSET_PATH/icon_32x32.png"
+          sips -z 16 16 ProductionAssets/AppIcon-iOS-Default-1024x1024@1x.png --out "$ICONSET_PATH/icon_16x16.png"
+          iconutil -c icns "$ICONSET_PATH" -o "$RUNNER_TEMP/VolumeIcon.icns"
+
       - name: Create DMG
         run: |
           DMG_PATH="$RUNNER_TEMP/BusyLight-${{ steps.version.outputs.version }}.dmg"
@@ -153,6 +165,7 @@ jobs:
 
           create-dmg \
             --volname "$PRODUCT_NAME" \
+            --volicon "$RUNNER_TEMP/VolumeIcon.icns" \
             --window-pos 200 120 \
             --window-size 600 400 \
             --icon-size 100 \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,208 @@
+name: Release Build
+
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number (e.g. 1.2.3)'
+        required: true
+
+env:
+  SCHEME: BusyLight
+  PROJECT: BusyLight.xcodeproj
+  PRODUCT_NAME: "Busy Light"
+  APP_BUNDLE_ID: com.mboszko.BusyLight
+
+jobs:
+  build-and-release:
+    name: Build, Sign, Notarize & Release
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          BUILD_NUMBER=$(date -u +"%y%m%d.%H%M")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "build_number=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION, Build: $BUILD_NUMBER"
+
+      - name: Install tools
+        run: brew install xcodegen create-dmg
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Import signing certificate
+        env:
+          P12_BASE64: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_BASE64 }}
+          P12_PASSWORD: ${{ secrets.DEVELOPER_ID_APPLICATION_P12_PASSWORD }}
+        run: |
+          # Create a temporary keychain
+          KEYCHAIN_PATH="$RUNNER_TEMP/signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 32)"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import certificate
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+          echo "$P12_BASE64" | base64 --decode > "$CERT_PATH"
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$P12_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          rm "$CERT_PATH"
+
+          # Allow codesign to access the keychain
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Add to search list
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | tr -d '"')
+
+          # Save keychain path for cleanup
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> "$GITHUB_ENV"
+
+      - name: Build archive
+        run: |
+          ARCHIVE_PATH="$RUNNER_TEMP/BusyLight.xcarchive"
+          xcodebuild archive \
+            -project "$PROJECT" \
+            -scheme "$SCHEME" \
+            -configuration Release \
+            -archivePath "$ARCHIVE_PATH" \
+            MARKETING_VERSION="${{ steps.version.outputs.version }}" \
+            CURRENT_PROJECT_VERSION="${{ steps.version.outputs.build_number }}" \
+            DEVELOPMENT_TEAM="${{ secrets.APPLE_TEAM_ID }}" \
+            CODE_SIGN_IDENTITY="Developer ID Application" \
+            CODE_SIGN_STYLE=Manual \
+            OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_PATH" \
+            | xcpretty
+          echo "ARCHIVE_PATH=$ARCHIVE_PATH" >> "$GITHUB_ENV"
+
+      - name: Export archive
+        run: |
+          EXPORT_PATH="$RUNNER_TEMP/export"
+
+          # Create export options plist
+          cat > "$RUNNER_TEMP/ExportOptions.plist" << 'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>developer-id</string>
+              <key>teamID</key>
+          PLIST
+          echo "    <string>${{ secrets.APPLE_TEAM_ID }}</string>" >> "$RUNNER_TEMP/ExportOptions.plist"
+          cat >> "$RUNNER_TEMP/ExportOptions.plist" << 'PLIST'
+              <key>signingStyle</key>
+              <string>manual</string>
+              <key>signingCertificate</key>
+              <string>Developer ID Application</string>
+          </dict>
+          </plist>
+          PLIST
+
+          xcodebuild -exportArchive \
+            -archivePath "$ARCHIVE_PATH" \
+            -exportPath "$EXPORT_PATH" \
+            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist" \
+            | xcpretty
+
+          echo "EXPORT_PATH=$EXPORT_PATH" >> "$GITHUB_ENV"
+
+      - name: Notarize app
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          APP_PATH="$EXPORT_PATH/$PRODUCT_NAME.app"
+
+          # Create a zip for notarization
+          ditto -c -k --keepParent "$APP_PATH" "$RUNNER_TEMP/app.zip"
+
+          # Submit for notarization
+          xcrun notarytool submit "$RUNNER_TEMP/app.zip" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+
+          # Staple the notarization ticket
+          xcrun stapler staple "$APP_PATH"
+
+          rm "$RUNNER_TEMP/app.zip"
+
+      - name: Create DMG
+        run: |
+          DMG_PATH="$RUNNER_TEMP/BusyLight-${{ steps.version.outputs.version }}.dmg"
+          APP_PATH="$EXPORT_PATH/$PRODUCT_NAME.app"
+
+          create-dmg \
+            --volname "$PRODUCT_NAME" \
+            --volicon "$APP_PATH/Contents/Resources/AppIcon.icns" \
+            --window-pos 200 120 \
+            --window-size 600 400 \
+            --icon-size 100 \
+            --icon "$PRODUCT_NAME.app" 150 190 \
+            --hide-extension "$PRODUCT_NAME.app" \
+            --app-drop-link 450 190 \
+            "$DMG_PATH" \
+            "$APP_PATH"
+
+          echo "DMG_PATH=$DMG_PATH" >> "$GITHUB_ENV"
+
+      - name: Notarize DMG
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          xcrun notarytool submit "$DMG_PATH" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_ID_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+
+          xcrun stapler staple "$DMG_PATH"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="v$VERSION"
+
+          # For workflow_dispatch, create the tag if it doesn't exist
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
+
+          gh release create "$TAG" \
+            "$DMG_PATH" \
+            --title "Busy Light $VERSION" \
+            --generate-notes
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          if [ -n "$KEYCHAIN_PATH" ]; then
+            security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
+          fi

--- a/BusyLight/Services/HelpManager.swift
+++ b/BusyLight/Services/HelpManager.swift
@@ -11,7 +11,7 @@ enum HelpManager {
     /// - `"getting-started"` — Getting Started
     /// - `"adding-scenes"` — Adding Scenes
     /// - `"using-triggers"` — Using Triggers
-    static func openHelp(anchor: String = "busylight-help") {
+    @MainActor static func openHelp(anchor: String = "busylight-help") {
         NSHelpManager.shared.openHelpAnchor(
             anchor as NSHelpManager.AnchorName,
             inBook: bookName

--- a/BusyLight/Services/SceneUndoHandler.swift
+++ b/BusyLight/Services/SceneUndoHandler.swift
@@ -16,11 +16,13 @@ final class SceneUndoHandler {
         let savedShortcuts = AppSettings.shared.keyboardShortcuts
 
         undoManager?.registerUndo(withTarget: self) { handler in
-            handler.restoreSnapshot(
-                menuItems: savedMenuItems,
-                shortcuts: savedShortcuts,
-                actionName: actionName
-            )
+            MainActor.assumeIsolated {
+                handler.restoreSnapshot(
+                    menuItems: savedMenuItems,
+                    shortcuts: savedShortcuts,
+                    actionName: actionName
+                )
+            }
         }
         undoManager?.setActionName(actionName)
     }

--- a/project.yml
+++ b/project.yml
@@ -30,7 +30,7 @@ targets:
         type: folder
         buildPhase: resources
       - path: AppIcon.icon
-        buildPhase: resources
+        buildPhase: sources
     postBuildScripts:
       - name: "Generate Help Index"
         script: |

--- a/project.yml
+++ b/project.yml
@@ -29,6 +29,8 @@ targets:
       - path: BusyLight/BusyLight.help
         type: folder
         buildPhase: resources
+      - path: AppIcon.icon
+        buildPhase: resources
     postBuildScripts:
       - name: "Generate Help Index"
         script: |

--- a/project.yml
+++ b/project.yml
@@ -7,6 +7,10 @@ options:
   createIntermediateGroups: true
   generateEmptyDirectories: true
 
+configs:
+  Debug: debug
+  Release: release
+
 settings:
   base:
     SWIFT_VERSION: "6.0"
@@ -42,6 +46,10 @@ targets:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         COMBINE_HIDPI_IMAGES: YES
         SWIFT_STRICT_CONCURRENCY: complete
+      configs:
+        Release:
+          CODE_SIGN_IDENTITY: "Developer ID Application"
+          CODE_SIGN_STYLE: Manual
     entitlements:
       path: BusyLight/BusyLight.entitlements
       properties: {}


### PR DESCRIPTION
## Summary

Closes #1

- Adds GitHub Actions workflow for automated release builds triggered by version tags or manual dispatch
- Updates `project.yml` with Release configuration and Developer ID signing settings
- Pipeline: xcodegen → archive → sign → notarize app → create-dmg → notarize DMG → GitHub Release
- Build numbers use date format `yymmdd.hhmm`

## Required Setup

Before first use, add these repository secrets:

| Secret | Description |
|--------|-------------|
| `DEVELOPER_ID_APPLICATION_P12_BASE64` | Base64-encoded .p12 certificate |
| `DEVELOPER_ID_APPLICATION_P12_PASSWORD` | .p12 password |
| `APPLE_ID` | Apple ID for notarization |
| `APPLE_ID_PASSWORD` | App-specific password |
| `APPLE_TEAM_ID` | Apple Developer Team ID |

## Test plan

- [x] Add all required secrets to the repository
- [x] Trigger workflow manually with `workflow_dispatch` and a test version (e.g., `0.0.1`)
- [x] Verify all steps complete: build, sign, notarize, DMG creation, release
- [x] Download DMG from release, mount it, verify app launches without Gatekeeper warnings
- [x] Run `spctl --assess --type execute "Busy Light.app"` to confirm notarization
- [ ] Test tag-based trigger by pushing a version tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)