### PR TITLE
Fix Revert Scene after manual scene change

### DIFF
--- a/BusyLight/Services/TriggerManager.swift
+++ b/BusyLight/Services/TriggerManager.swift
@@ -10,6 +10,10 @@ final class TriggerManager {
     /// Stores the scene that was active before a trigger fired, so we can revert to it.
     private var previousSceneId: String?
 
+    /// The entity ID most recently activated by a trigger. Used to detect whether
+    /// the user manually changed the scene between trigger-on and trigger-off.
+    private var lastTriggerSetEntityId: String?
+
     func startAllMonitors() {
         CameraMonitor.shared.startMonitoring()
         MicrophoneMonitor.shared.startMonitoring()
@@ -169,17 +173,31 @@ final class TriggerManager {
             previousSceneId = settings.activeSceneId
         }
 
+        lastTriggerSetEntityId = entityId
         MenuBarManager.shared.activateScene(entityId: entityId)
     }
 
     /// Reverts to the scene that was active before a trigger fired.
+    /// If the user manually changed the scene after the trigger, their choice
+    /// is preserved instead of reverting to the stale pre-trigger scene.
     private func revertToPreviousScene() {
+        defer {
+            previousSceneId = nil
+            lastTriggerSetEntityId = nil
+        }
+
+        // If the active scene differs from what the trigger set, the user
+        // manually changed it — respect their choice and don't revert.
+        if let lastTrigger = lastTriggerSetEntityId,
+           settings.activeSceneId != lastTrigger {
+            return
+        }
+
         if let previous = previousSceneId {
             MenuBarManager.shared.activateScene(entityId: previous)
         } else {
             // No previous scene to revert to; clear active scene
             MenuBarManager.shared.deactivateScene()
         }
-        previousSceneId = nil
     }
 }

--- a/BusyLightTests/Services/TriggerManagerTests.swift
+++ b/BusyLightTests/Services/TriggerManagerTests.swift
@@ -26,6 +26,98 @@ final class TriggerManagerTests: XCTestCase {
         XCTAssertEqual(Notification.Name.focusModeChanged.rawValue, "BusyLight.focusModeChanged")
     }
 
+    // MARK: - Revert Scene behavior
+
+    override func tearDown() {
+        TriggerManager.shared.stopAllMonitors()
+        let settings = AppSettings.shared
+        settings.activeSceneId = nil
+        settings.webcamTriggerEnabled = false
+        settings.webcamOnSceneId = ""
+        settings.webcamOffTriggerEnabled = false
+        settings.webcamOffSceneId = ""
+        super.tearDown()
+    }
+
+    /// Helper: post a camera state notification and let observers process it.
+    private func postCameraChange(isOn: Bool) async {
+        NotificationCenter.default.post(
+            name: .cameraStateChanged,
+            object: nil,
+            userInfo: ["isOn": isOn]
+        )
+        // Yield to let the notification observer's Task run
+        await Task.yield()
+        await Task.yield()
+    }
+
+    func testRevertSceneNormalBehavior() async {
+        let settings = AppSettings.shared
+        settings.webcamTriggerEnabled = true
+        settings.webcamOnSceneId = "scene.busy"
+        settings.webcamOffTriggerEnabled = true
+        settings.webcamOffSceneId = AppSettings.revertSceneId
+        settings.activeSceneId = "scene.free"
+
+        TriggerManager.shared.startAllMonitors()
+
+        // Camera on → trigger activates "Busy"
+        await postCameraChange(isOn: true)
+        XCTAssertEqual(settings.activeSceneId, "scene.busy")
+
+        // Camera off → revert to "Free"
+        await postCameraChange(isOn: false)
+        XCTAssertEqual(settings.activeSceneId, "scene.free",
+                       "Should revert to pre-trigger scene when no manual change occurred")
+    }
+
+    func testRevertSceneRespectsManualChange() async {
+        let settings = AppSettings.shared
+        settings.webcamTriggerEnabled = true
+        settings.webcamOnSceneId = "scene.busy"
+        settings.webcamOffTriggerEnabled = true
+        settings.webcamOffSceneId = AppSettings.revertSceneId
+        settings.activeSceneId = "scene.free"
+
+        TriggerManager.shared.startAllMonitors()
+
+        // Camera on → trigger activates "Busy"
+        await postCameraChange(isOn: true)
+        XCTAssertEqual(settings.activeSceneId, "scene.busy")
+
+        // User manually changes scene
+        MenuBarManager.shared.activateScene(entityId: "scene.concentrating")
+        XCTAssertEqual(settings.activeSceneId, "scene.concentrating")
+
+        // Camera off → revert should keep "Concentrating", not go back to "Free"
+        await postCameraChange(isOn: false)
+        XCTAssertEqual(settings.activeSceneId, "scene.concentrating",
+                       "Should keep user's manual choice, not revert to stale pre-trigger scene")
+    }
+
+    func testRevertSceneRespectsMultipleManualChanges() async {
+        let settings = AppSettings.shared
+        settings.webcamTriggerEnabled = true
+        settings.webcamOnSceneId = "scene.busy"
+        settings.webcamOffTriggerEnabled = true
+        settings.webcamOffSceneId = AppSettings.revertSceneId
+        settings.activeSceneId = "scene.free"
+
+        TriggerManager.shared.startAllMonitors()
+
+        // Camera on → trigger activates "Busy"
+        await postCameraChange(isOn: true)
+
+        // User changes scene twice
+        MenuBarManager.shared.activateScene(entityId: "scene.concentrating")
+        MenuBarManager.shared.activateScene(entityId: "scene.available")
+
+        // Camera off → should stay on last manual choice
+        await postCameraChange(isOn: false)
+        XCTAssertEqual(settings.activeSceneId, "scene.available",
+                       "Should keep user's last manual choice")
+    }
+
     func testConnectionStateEquality() {
         XCTAssertEqual(ConnectionState.connected, ConnectionState.connected)
         XCTAssertEqual(ConnectionState.disconnected, ConnectionState.disconnected)


### PR DESCRIPTION
## Summary

- Track `lastTriggerSetEntityId` in TriggerManager to detect when the user manually changes the scene during an active trigger chain
- When reverting, compare current scene against the trigger-set scene — if they differ, preserve the user's manual choice instead of reverting to the stale pre-trigger scene
- Minimal fix: 1 new property, ~10 lines changed in TriggerManager

Fixes #5

## Test plan

- [x] 131 tests pass (128 existing + 3 new)
- [x] `testRevertSceneNormalBehavior` — normal revert still works
- [x] `testRevertSceneRespectsManualChange` — manual change during trigger chain is preserved
- [x] `testRevertSceneRespectsMultipleManualChanges` — multiple manual changes preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)