### PR TITLE
Replace GCD with modern Swift concurrency, fix deprecated API

### DIFF
--- a/BusyLight/AppDelegate.swift
+++ b/BusyLight/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // First-run welcome dialog (deferred so the app finishes launching first)
         if !AppSettings.shared.hasCompletedFirstRun {
-            DispatchQueue.main.async { [self] in
+            Task { @MainActor in
                 showFirstRunDialog()
             }
         }
@@ -26,14 +26,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc private func handleOpenSettings(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
-        NSApp.activate(ignoringOtherApps: true)
+        NSApp.activate()
 
         // Open the Settings window via the captured SwiftUI openSettings action.
         // SettingsOpener captures this from MenuBarLabelView, which is always live.
         SettingsOpener.shared.openSettings()
 
         // Rename the settings window and remove the View menu after they appear.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(300))
             if let settingsWindow = NSApp.windows.first(where: {
                 $0.isVisible && $0.styleMask.contains(.titled)
             }) {

--- a/BusyLight/Views/Utility/EmojiPickerButton.swift
+++ b/BusyLight/Views/Utility/EmojiPickerButton.swift
@@ -177,7 +177,7 @@ final class EmojiInputProxy: NSObject, NSTextViewDelegate {
         // the context isn't active yet and the palette silently fails to open
         // (reproduces as "first click does nothing").  One async hop lets the
         // run-loop complete the initialisation before the palette attaches.
-        DispatchQueue.main.async {
+        Task { @MainActor in
             NSApp.orderFrontCharacterPalette(nil)
         }
     }


### PR DESCRIPTION
## Summary

- Replace 3 `DispatchQueue` calls with `Task { @MainActor in }` / `Task.sleep(for:)`
- Replace deprecated `NSApp.activate(ignoringOtherApps:)` with `NSApp.activate()`
- Documents in issue #29 why remaining AppKit usage is necessary (Character Palette, key monitoring, Help Books, AppleScript, activation policy)
- `tabItem` stays — the `Tab` API requires macOS 15, and we target macOS 14

Fixes #29

## Test plan

- [x] 131 tests pass, 0 failures
- [ ] Settings window opens and titles correctly after 300ms delay
- [ ] Emoji picker Character Palette opens on first click
- [ ] First-run dialog appears on clean launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)