### PR TITLE
Fix false unlock trigger on wake from sleep

### DIFF
--- a/BusyLight/Services/ScreenLockMonitor.swift
+++ b/BusyLight/Services/ScreenLockMonitor.swift
@@ -11,7 +11,6 @@ final class ScreenLockMonitor {
     private var lockObserver: NSObjectProtocol?
     private var unlockObserver: NSObjectProtocol?
     private var sleepObserver: NSObjectProtocol?
-    private var wakeObserver: NSObjectProtocol?
     private var isMonitoring = false
 
     func startMonitoring() {
@@ -55,16 +54,6 @@ final class ScreenLockMonitor {
             )
         }
 
-        wakeObserver = workspace.addObserver(
-            forName: NSWorkspace.didWakeNotification,
-            object: nil, queue: .main
-        ) { _ in
-            NotificationCenter.default.post(
-                name: .screenLockStateChanged,
-                object: nil,
-                userInfo: ["isLocked": false]
-            )
-        }
     }
 
     func stopMonitoring() {
@@ -74,12 +63,10 @@ final class ScreenLockMonitor {
 
         let workspace = NSWorkspace.shared.notificationCenter
         if let o = sleepObserver { workspace.removeObserver(o) }
-        if let o = wakeObserver { workspace.removeObserver(o) }
 
         lockObserver = nil
         unlockObserver = nil
         sleepObserver = nil
-        wakeObserver = nil
         isMonitoring = false
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ xcodebuild test -project BusyLight.xcodeproj -scheme BusyLight -destination 'pla
 - `HomeAssistantService`: Actor with async/await REST API client, exponential backoff retry, connection health checks
 - `CameraMonitor`: CoreMediaIO `kCMIODevicePropertyDeviceIsRunningSomewhere` (2s polling)
 - `MicrophoneMonitor`: CoreAudio `kAudioDevicePropertyDeviceIsRunningSomewhere` (2s polling)
-- `ScreenLockMonitor`: `DistributedNotificationCenter` for lock/unlock/sleep/wake
+- `ScreenLockMonitor`: `DistributedNotificationCenter` for lock/unlock, `NSWorkspace` for sleep
 - `FocusModeMonitor`: Reads `~/Library/DoNotDisturb/DB/Assertions.json` (5s polling, experimental)
 - `GlobalHotkeyManager`: `NSEvent.addGlobalMonitorForEvents` for system-wide keyboard shortcuts
 - `TriggerManager`: Coordinates all monitors, applies trigger settings, camera > mic priority


### PR DESCRIPTION
## Summary

- Remove `didWakeNotification` observer from `ScreenLockMonitor` that incorrectly fired `isLocked: false` on wake
- Wake from sleep requires authentication — the actual unlock is already handled by the `com.apple.screenIsUnlocked` distributed notification
- Keep `willSleepNotification → isLocked: true` since sleep does lock the screen

Fixes #6

## Test plan

- [x] 127 tests pass, 0 failures
- [ ] Put Mac to sleep → wake → verify "screen unlocked" trigger does NOT fire until password is entered
- [ ] Lock screen (⌃⌘Q) → unlock → verify trigger fires correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)