### PR TITLE
Debounce undo snapshots for scene name editing

### DIFF
--- a/BusyLight/Views/Settings/ScenesTab.swift
+++ b/BusyLight/Views/Settings/ScenesTab.swift
@@ -8,6 +8,8 @@ struct ScenesTab: View {
     @State private var isFetching = false
     @State private var fetchError: String?
     @State private var selectedItemId: String?
+    @FocusState private var focusedNameIndex: Int?
+    @State private var nameEditSnapshotIndex: Int?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -51,6 +53,9 @@ struct ScenesTab: View {
                 }
                 .listStyle(.bordered)
                 .onDeleteCommand(perform: removeSelectedItem)
+                .onChange(of: focusedNameIndex) { _, _ in
+                    nameEditSnapshotIndex = nil
+                }
             }
 
             // +/- toolbar buttons
@@ -111,6 +116,7 @@ struct ScenesTab: View {
                 EmojiPickerButton(emoji: bindingForEmoji(at: index))
 
                 TextField("Display Name", text: bindingForName(at: index))
+                    .focused($focusedNameIndex, equals: index)
                     .frame(minWidth: 100, maxWidth: 140)
 
                 Text(scene.entityId)
@@ -162,7 +168,10 @@ struct ScenesTab: View {
             set: { newValue in
                 guard index < settings.menuItems.count,
                       case .scene(var scene) = settings.menuItems[index] else { return }
-                undoHandler.saveSnapshot(actionName: "Change Name")
+                if nameEditSnapshotIndex != index {
+                    undoHandler.saveSnapshot(actionName: "Change Name")
+                    nameEditSnapshotIndex = index
+                }
                 scene.displayName = newValue
                 settings.menuItems[index] = .scene(scene)
             }


### PR DESCRIPTION
## Summary

- Only save an undo snapshot on the **first** keystroke per editing session, not every character
- Use `@FocusState` to detect when the user moves between name fields, resetting the snapshot tracking
- Undo now reverts the entire name change rather than one character at a time
- Eliminates per-keystroke JSON serialization of menuItems + keyboardShortcuts

Fixes #8

## Test plan

- [x] 127 tests pass, 0 failures
- [ ] Type a scene name — undo (⌘Z) reverts the whole name, not one character
- [ ] Edit name A, click name B, edit — undo reverts B's change, then A's change
- [ ] Emoji picks still get individual undo snapshots (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)