### PR TITLE
Suppress camera/mic triggers when screen is locked

### DIFF
--- a/BusyLight/Services/ScreenLockMonitor.swift
+++ b/BusyLight/Services/ScreenLockMonitor.swift
@@ -8,6 +8,10 @@ extension Notification.Name {
 final class ScreenLockMonitor {
     static let shared = ScreenLockMonitor()
 
+    /// Whether the screen is currently locked or the Mac is asleep.
+    /// Used by TriggerManager to suppress camera/mic triggers during Power Nap.
+    private(set) var isScreenLocked = false
+
     private var lockObserver: NSObjectProtocol?
     private var unlockObserver: NSObjectProtocol?
     private var sleepObserver: NSObjectProtocol?
@@ -22,7 +26,8 @@ final class ScreenLockMonitor {
         lockObserver = dnc.addObserver(
             forName: NSNotification.Name("com.apple.screenIsLocked"),
             object: nil, queue: .main
-        ) { _ in
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.isScreenLocked = true }
             NotificationCenter.default.post(
                 name: .screenLockStateChanged,
                 object: nil,
@@ -33,7 +38,8 @@ final class ScreenLockMonitor {
         unlockObserver = dnc.addObserver(
             forName: NSNotification.Name("com.apple.screenIsUnlocked"),
             object: nil, queue: .main
-        ) { _ in
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.isScreenLocked = false }
             NotificationCenter.default.post(
                 name: .screenLockStateChanged,
                 object: nil,
@@ -46,7 +52,8 @@ final class ScreenLockMonitor {
         sleepObserver = workspace.addObserver(
             forName: NSWorkspace.willSleepNotification,
             object: nil, queue: .main
-        ) { _ in
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.isScreenLocked = true }
             NotificationCenter.default.post(
                 name: .screenLockStateChanged,
                 object: nil,

--- a/BusyLight/Services/TriggerManager.swift
+++ b/BusyLight/Services/TriggerManager.swift
@@ -106,9 +106,11 @@ final class TriggerManager {
 
     // MARK: - Handlers
 
-    /// Camera triggers take highest priority over microphone triggers
+    /// Camera triggers take highest priority over microphone triggers.
+    /// Suppressed when the screen is locked to avoid false triggers during Power Nap.
     private func handleCameraChange(isOn: Bool?) {
         guard let isOn else { return }
+        guard !ScreenLockMonitor.shared.isScreenLocked else { return }
 
         if isOn && settings.webcamTriggerEnabled && !settings.webcamOnSceneId.isEmpty {
             activateScene(entityId: settings.webcamOnSceneId)
@@ -117,9 +119,11 @@ final class TriggerManager {
         }
     }
 
-    /// Microphone triggers only fire when camera is not active (camera has priority)
+    /// Microphone triggers only fire when camera is not active (camera has priority).
+    /// Suppressed when the screen is locked to avoid false triggers during Power Nap.
     private func handleMicChange(isOn: Bool?) {
         guard let isOn else { return }
+        guard !ScreenLockMonitor.shared.isScreenLocked else { return }
 
         // Don't override camera trigger
         if CameraMonitor.shared.isCameraOn { return }


### PR DESCRIPTION
## Summary

- Add `isScreenLocked` property to `ScreenLockMonitor` that tracks lock/sleep state
- Guard `handleCameraChange` and `handleMicChange` in `TriggerManager` to skip when screen is locked
- Prevents false triggers during Power Nap when USB devices briefly power up the camera

Fixes #2

## Test plan

- [x] 127 tests pass, 0 failures
- [ ] Lock screen → camera trigger should NOT fire
- [ ] Unlock screen → camera trigger works normally
- [ ] Sleep/wake cycle → camera briefly activating should be suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)