### PR TITLE
Replace 300ms sleep with deterministic NSWindow observer

### DIFF
--- a/BusyLight/AppDelegate.swift
+++ b/BusyLight/AppDelegate.swift
@@ -28,24 +28,31 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate()
 
-        // Open the Settings window via the captured SwiftUI openSettings action.
-        // SettingsOpener captures this from MenuBarLabelView, which is always live.
-        SettingsOpener.shared.openSettings()
+        // Listen for the Settings window to become key, then rename it and
+        // strip the unwanted View menu.  One-shot: removes itself after firing.
+        var token: NSObjectProtocol?
+        token = NotificationCenter.default.addObserver(
+            forName: NSWindow.didBecomeKeyNotification,
+            object: nil,
+            queue: .main
+        ) { windowNotification in
+            guard let window = windowNotification.object as? NSWindow,
+                  window.styleMask.contains(.titled) else { return }
 
-        // Rename the settings window and remove the View menu after they appear.
-        Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(300))
-            if let settingsWindow = NSApp.windows.first(where: {
-                $0.isVisible && $0.styleMask.contains(.titled)
-            }) {
-                settingsWindow.title = "Settings"
-                settingsWindow.makeKeyAndOrderFront(nil)
-                settingsWindow.orderFrontRegardless()
-            }
+            window.title = "Settings"
+            window.makeKeyAndOrderFront(nil)
+            window.orderFrontRegardless()
+
             if let viewMenu = NSApp.mainMenu?.item(withTitle: "View") {
                 NSApp.mainMenu?.removeItem(viewMenu)
             }
+
+            if let token { NotificationCenter.default.removeObserver(token) }
         }
+
+        // Open the Settings window via the captured SwiftUI openSettings action.
+        // SettingsOpener captures this from MenuBarLabelView, which is always live.
+        SettingsOpener.shared.openSettings()
     }
 
     private func showFirstRunDialog() {


### PR DESCRIPTION
## Summary

- Replaced the fragile `Task.sleep(for: .milliseconds(300))` hack in `handleOpenSettings` with a one-shot `NSWindow.didBecomeKeyNotification` observer
- The observer fires as soon as the Settings window actually becomes key, then renames the title, brings it to front, and removes the View menu — no timing dependency
- Observer self-removes after firing

Fixes #9

## Test plan

- [ ] Click Settings from menu bar — window opens with "Settings" title, no visible delay
- [ ] Open Settings during first-run dialog — same behavior
- [ ] Verify View menu is removed from the menu bar
- [ ] 127 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)