### PR TITLE
Add URL sanitization for Home Assistant base URL

### DIFF
--- a/BusyLight/Utilities/URLSanitizer.swift
+++ b/BusyLight/Utilities/URLSanitizer.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+enum URLSanitizer {
+    /// Cleans a user-entered Home Assistant base URL:
+    /// 1. Trims leading/trailing whitespace
+    /// 2. Strips trailing slashes
+    /// 3. Prepends `http://` if no scheme is present
+    static func sanitize(_ input: String) -> String {
+        var result = input.trimmingCharacters(in: .whitespaces)
+
+        guard !result.isEmpty else { return result }
+
+        // Prepend scheme if missing
+        if !result.lowercased().hasPrefix("http://") && !result.lowercased().hasPrefix("https://") {
+            result = "http://" + result
+        }
+
+        // Strip trailing slashes
+        while result.hasSuffix("/") {
+            result.removeLast()
+        }
+
+        return result
+    }
+
+    /// Returns `true` if the sanitized URL can be parsed by `URL(string:)`
+    /// and has a non-empty host.
+    static func isValid(_ url: String) -> Bool {
+        guard !url.isEmpty,
+              let parsed = URL(string: url),
+              parsed.host() != nil,
+              !parsed.host()!.isEmpty else {
+            return false
+        }
+        return true
+    }
+}

--- a/BusyLight/Views/Settings/HomeAssistantTab.swift
+++ b/BusyLight/Views/Settings/HomeAssistantTab.swift
@@ -6,6 +6,8 @@ struct HomeAssistantTab: View {
     @State private var isTesting = false
     @State private var tokenText: String = ""
 
+    @State private var urlWarning: String?
+
     enum ConnectionStatus {
         case unknown, testing, success, failure(String)
     }
@@ -15,6 +17,13 @@ struct HomeAssistantTab: View {
             Section("Connection") {
                 TextField("URL", text: $settings.haBaseURL, prompt: Text("http://homeassistant.local:8123"))
                     .textFieldStyle(.roundedBorder)
+                    .onSubmit { sanitizeAndValidateURL() }
+
+                if let urlWarning {
+                    Text(urlWarning)
+                        .foregroundStyle(.orange)
+                        .font(.caption)
+                }
 
                 SecureField("Long-Lived Access Token", text: $tokenText)
                     .textFieldStyle(.roundedBorder)
@@ -68,7 +77,22 @@ struct HomeAssistantTab: View {
         }
     }
 
+    private func sanitizeAndValidateURL() {
+        let sanitized = URLSanitizer.sanitize(settings.haBaseURL)
+        settings.haBaseURL = sanitized
+
+        if sanitized.isEmpty {
+            urlWarning = nil
+        } else if !URLSanitizer.isValid(sanitized) {
+            urlWarning = "This doesn\u{2019}t look like a valid URL"
+        } else {
+            urlWarning = nil
+        }
+    }
+
     private func testConnection() {
+        sanitizeAndValidateURL()
+        guard urlWarning == nil else { return }
         isTesting = true
         connectionStatus = .testing
         Task {

--- a/BusyLightTests/Utilities/URLSanitizerTests.swift
+++ b/BusyLightTests/Utilities/URLSanitizerTests.swift
@@ -1,0 +1,63 @@
+import Testing
+@testable import BusyLight
+
+struct URLSanitizerTests {
+
+    // MARK: - Sanitize
+
+    @Test func sanitizeTrimsWhitespace() {
+        #expect(URLSanitizer.sanitize("  http://ha.local:8123  ") == "http://ha.local:8123")
+    }
+
+    @Test func sanitizeStripsTrailingSlashes() {
+        #expect(URLSanitizer.sanitize("http://ha.local:8123/") == "http://ha.local:8123")
+        #expect(URLSanitizer.sanitize("http://ha.local:8123///") == "http://ha.local:8123")
+    }
+
+    @Test func sanitizePrependsSchemeWhenMissing() {
+        #expect(URLSanitizer.sanitize("homeassistant.local:8123") == "http://homeassistant.local:8123")
+    }
+
+    @Test func sanitizePreservesHTTPS() {
+        #expect(URLSanitizer.sanitize("https://ha.local:8123") == "https://ha.local:8123")
+    }
+
+    @Test func sanitizePreservesHTTPSCaseInsensitive() {
+        #expect(URLSanitizer.sanitize("HTTPS://ha.local:8123") == "HTTPS://ha.local:8123")
+    }
+
+    @Test func sanitizeHandlesEmptyString() {
+        #expect(URLSanitizer.sanitize("") == "")
+    }
+
+    @Test func sanitizeHandlesWhitespaceOnly() {
+        #expect(URLSanitizer.sanitize("   ") == "")
+    }
+
+    @Test func sanitizeCombinesAllFixes() {
+        // Whitespace + no scheme + trailing slash
+        #expect(URLSanitizer.sanitize("  ha.local:8123/  ") == "http://ha.local:8123")
+    }
+
+    @Test func sanitizePreservesPath() {
+        #expect(URLSanitizer.sanitize("http://ha.local:8123/path") == "http://ha.local:8123/path")
+    }
+
+    // MARK: - Validation
+
+    @Test func validURLPasses() {
+        #expect(URLSanitizer.isValid("http://ha.local:8123"))
+    }
+
+    @Test func emptyStringIsInvalid() {
+        #expect(!URLSanitizer.isValid(""))
+    }
+
+    @Test func schemeOnlyIsInvalid() {
+        #expect(!URLSanitizer.isValid("http://"))
+    }
+
+    @Test func validHTTPSPasses() {
+        #expect(URLSanitizer.isValid("https://homeassistant.example.com"))
+    }
+}


### PR DESCRIPTION
## Summary

- Added `URLSanitizer` utility that trims whitespace, strips trailing slashes, and prepends `http://` when no scheme is present
- `HomeAssistantTab` now sanitizes the URL on submit (Return/Tab) and before testing the connection
- Inline validation warning shown if the sanitized URL can't be parsed
- 13 new unit tests covering all edge cases (empty, whitespace, missing scheme, HTTPS preserved, trailing slashes, combined fixes)

Fixes #10

## Test plan

- [ ] Enter `homeassistant.local:8123` → on submit, auto-corrects to `http://homeassistant.local:8123`
- [ ] Enter `http://ha.local:8123/` → trailing slash stripped
- [ ] Enter `  https://ha.local  ` → whitespace trimmed, scheme preserved
- [ ] Enter gibberish → orange warning shown
- [ ] Test Connection with invalid URL → blocked, no network request
- [ ] 127 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)