### PR TITLE
Fix health check Task overlap with generation counter

### DIFF
--- a/BusyLight/Services/HomeAssistantService.swift
+++ b/BusyLight/Services/HomeAssistantService.swift
@@ -63,6 +63,7 @@ actor HomeAssistantService {
 
     private let session: URLSession
     private var healthCheckTask: Task<Void, Never>?
+    private var healthCheckGeneration: Int = 0
 
     private(set) var connectionState: ConnectionState = .unknown
 
@@ -94,24 +95,24 @@ actor HomeAssistantService {
 
     func startHealthChecks(baseURL: String, token: String) {
         stopHealthChecks()
+        healthCheckGeneration += 1
+        let myGeneration = healthCheckGeneration
         healthCheckTask = Task {
             while !Task.isCancelled {
                 do {
                     _ = try await self.testConnection(baseURL: baseURL, token: token)
-                    // connectionState is set inside testConnection
                 } catch {
-                    await self.setConnectionState(.disconnected)
+                    self.connectionState = .disconnected
                 }
+                // Exit if a newer health check loop has started
+                guard myGeneration == self.healthCheckGeneration else { break }
                 try? await Task.sleep(for: .seconds(30))
             }
         }
     }
 
-    private func setConnectionState(_ state: ConnectionState) {
-        connectionState = state
-    }
-
     func stopHealthChecks() {
+        healthCheckGeneration += 1
         healthCheckTask?.cancel()
         healthCheckTask = nil
     }

--- a/BusyLightTests/Services/HomeAssistantServiceTests.swift
+++ b/BusyLightTests/Services/HomeAssistantServiceTests.swift
@@ -224,6 +224,31 @@ final class HomeAssistantServiceTests: XCTestCase {
         XCTAssertEqual(scene.entityId, "scene.test")
     }
 
+    // MARK: - Health Check Generation
+
+    func testStartHealthChecksSuperseedsPrevious() async throws {
+        // Mock a successful response
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = #"{"message": "API running."}"#.data(using: .utf8)!
+            return (response, data)
+        }
+
+        // Start health checks twice in quick succession
+        await service.startHealthChecks(baseURL: "http://localhost:8123", token: "token")
+        await service.startHealthChecks(baseURL: "http://localhost:8123", token: "token2")
+
+        // The first loop should exit on its next generation check.
+        // Stop to clean up.
+        await service.stopHealthChecks()
+    }
+
+    func testStopHealthChecksIncrementsGeneration() async {
+        // Calling stop without start should not crash
+        await service.stopHealthChecks()
+        await service.stopHealthChecks()
+    }
+
     // MARK: - SceneActivationResult
 
     func testSceneActivationResultSuccess() {

--- a/BusyLightTests/TestSetup.swift
+++ b/BusyLightTests/TestSetup.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import BusyLight
+
+/// Runs before any test class setUp — enables the in-memory keychain
+/// store so the app host process doesn't trigger a Keychain dialog
+/// when `TriggerManager.startAllMonitors()` reads `AppSettings.haToken`.
+final class TestSetup: NSObject {
+    override init() {
+        KeychainHelper.testStore = [:]
+        super.init()
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -71,6 +71,7 @@ targets:
         GENERATE_INFOPLIST_FILE: YES
         BUNDLE_LOADER: "$(TEST_HOST)"
         TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Busy Light.app/Contents/MacOS/Busy Light"
+        INFOPLIST_KEY_NSPrincipalClass: BusyLightTests.TestSetup
 
 schemes:
   BusyLight:


### PR DESCRIPTION
## Summary

- Added `healthCheckGeneration` counter to `HomeAssistantService` — each `startHealthChecks()` increments it, and the loop exits if its generation is stale
- `stopHealthChecks()` also increments generation for belt-and-suspenders safety alongside `Task.cancel()`
- Removed unused `setConnectionState` helper (direct property access inside actor)
- Added `TestSetup` principal class to set `KeychainHelper.testStore` before the app host launches, preventing the keychain authorization dialog during test runs
- 2 new tests covering rapid restart and double-stop scenarios

Fixes #11
Also fixes remaining keychain prompt from #39 (app host launch path)

## Test plan

- [ ] 129 tests pass (2 new), no keychain dialog
- [ ] Health checks restart cleanly when HA settings change
- [ ] No doubled network traffic on rapid settings changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)