### PR TITLE
Scope mic running check to input streams only

### DIFF
--- a/BusyLight/AppDelegate.swift
+++ b/BusyLight/AppDelegate.swift
@@ -4,6 +4,14 @@ import AppKit
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        #if DEBUG
+        // When running as a test host, bypass the system keychain to avoid
+        // the authorization dialog (we may be running remotely / unattended).
+        if ProcessInfo.processInfo.environment["XCInjectBundleInto"] != nil {
+            KeychainHelper.testStore = KeychainHelper.testStore ?? [:]
+        }
+        #endif
+
         TriggerManager.shared.startAllMonitors()
 
         // Handle opening the Settings window (activation policy + window title).

--- a/BusyLight/Services/MicrophoneMonitor.swift
+++ b/BusyLight/Services/MicrophoneMonitor.swift
@@ -84,7 +84,7 @@ final class MicrophoneMonitor {
             var runningSize = UInt32(MemoryLayout<UInt32>.size)
             var runningAddress = AudioObjectPropertyAddress(
                 mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
-                mScope: kAudioObjectPropertyScopeGlobal,
+                mScope: kAudioObjectPropertyScopeInput,
                 mElement: kAudioObjectPropertyElementMain
             )
 


### PR DESCRIPTION
## Summary

- Changed `kAudioDevicePropertyDeviceIsRunningSomewhere` scope from `kAudioObjectPropertyScopeGlobal` to `kAudioObjectPropertyScopeInput` in `MicrophoneMonitor.isAnyMicRunning()`
- Combo devices (USB headsets, audio interfaces) will no longer false-trigger mic-on when only their output is active
- Also fixed the keychain dialog regression: moved `testStore` setup into `AppDelegate.applicationDidFinishLaunching` (guarded by `XCInjectBundleInto` env var) so it runs before `startAllMonitors()` accesses the keychain

Fixes #12, also fixes #39

## Test plan

- [ ] USB headset playing music (no recording) → no mic trigger
- [ ] Built-in mic recording → still triggers correctly
- [ ] 129 tests pass, no keychain dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)