### PR TITLE
Add kSecAttrService to keychain queries with legacy migration

### DIFF
--- a/BusyLight/Services/KeychainHelper.swift
+++ b/BusyLight/Services/KeychainHelper.swift
@@ -11,6 +11,10 @@ enum KeychainHelper {
     nonisolated(unsafe) static var testStore: [String: String]?
     #endif
 
+    // MARK: - Constants
+
+    private static let serviceName = "com.mboszko.BusyLight"
+
     // MARK: - Public API
 
     static func save(key: String, value: String) {
@@ -26,6 +30,7 @@ enum KeychainHelper {
 
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
             kSecAttrAccount as String: key,
         ]
 
@@ -37,6 +42,7 @@ enum KeychainHelper {
 
         let addQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
             kSecAttrAccount as String: key,
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
@@ -54,6 +60,7 @@ enum KeychainHelper {
 
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
             kSecAttrAccount as String: key,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne,
@@ -62,13 +69,15 @@ enum KeychainHelper {
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
 
-        guard status == errSecSuccess,
-              let data = result as? Data,
-              let string = String(data: data, encoding: .utf8) else {
-            return nil
+        if status == errSecSuccess,
+           let data = result as? Data,
+           let string = String(data: data, encoding: .utf8) {
+            return string
         }
 
-        return string
+        // Migration: try loading from the old query (no service attribute).
+        // If found, migrate to the new format and delete the old entry.
+        return migrateFromLegacy(key: key)
     }
 
     static func delete(key: String) {
@@ -81,6 +90,7 @@ enum KeychainHelper {
 
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
             kSecAttrAccount as String: key,
         ]
 
@@ -100,6 +110,7 @@ enum KeychainHelper {
 
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: serviceName,
             kSecAttrAccount as String: key,
         ]
 
@@ -112,5 +123,39 @@ enum KeychainHelper {
         if status == errSecItemNotFound {
             save(key: key, value: value)
         }
+    }
+
+    // MARK: - Migration
+
+    /// Loads a value stored without `kSecAttrService` (pre-fix format).
+    /// If found, saves it with the service attribute and deletes the old entry.
+    private static func migrateFromLegacy(key: String) -> String? {
+        let legacyQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(legacyQuery as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        // Save with new format
+        save(key: key, value: value)
+
+        // Delete old entry
+        let deleteLegacy: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+        ]
+        SecItemDelete(deleteLegacy as CFDictionary)
+
+        return value
     }
 }


### PR DESCRIPTION
## Summary

- Added `kSecAttrService: "com.mboszko.BusyLight"` to all keychain queries (`save`, `load`, `delete`, `update`) to prevent namespace collisions
- `load()` falls back to a legacy query (no service attr) and transparently migrates the entry if found — existing users' HA tokens transfer seamlessly on first access
- Old entry is deleted after successful migration

Fixes #13

## Test plan

- [ ] Fresh install: token saves and loads correctly
- [ ] Upgrade from pre-fix version: existing token migrates on first load, old entry cleaned up
- [ ] Verify in Keychain Access.app that new entries show "com.mboszko.BusyLight" as the service
- [ ] 129 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)