### PR TITLE
Auto-clear duplicate keyboard shortcuts on assignment

### DIFF
--- a/BusyLight/Views/Utility/ShortcutRecorderView.swift
+++ b/BusyLight/Views/Utility/ShortcutRecorderView.swift
@@ -57,9 +57,11 @@ struct ShortcutRecorderView: View {
         keyMonitor.install { [sceneEntityId] keyCode, modifiers in
             // Capture undo snapshot before mutating shortcuts.
             onWillChange?()
-            // Upsert: remove any existing shortcut for this scene, then add the new one.
+            // Upsert: remove any existing shortcut for this scene, and clear
+            // any other scene that already uses the same key combo.
             var shortcuts = settings.keyboardShortcuts
             shortcuts.removeAll { $0.sceneEntityId == sceneEntityId }
+            shortcuts.removeAll { $0.keyCode == keyCode && $0.modifiers == modifiers }
             shortcuts.append(KeyboardShortcutConfig(
                 keyCode: keyCode,
                 modifiers: modifiers,

--- a/BusyLightTests/Models/AppSettingsTests.swift
+++ b/BusyLightTests/Models/AppSettingsTests.swift
@@ -130,6 +130,27 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertFalse(settings.hasCompletedFirstRun)
     }
 
+    func testDuplicateShortcutResolution() {
+        let settings = AppSettings.shared
+        // Assign ⌘Q (keyCode 12, modifiers 256) to scene.a
+        settings.keyboardShortcuts = [
+            KeyboardShortcutConfig(keyCode: 12, modifiers: 256, sceneEntityId: "scene.a"),
+        ]
+
+        // Simulate recording the same combo for scene.b (same logic as ShortcutRecorderView)
+        let keyCode: UInt16 = 12
+        let modifiers: UInt = 256
+        var shortcuts = settings.keyboardShortcuts
+        shortcuts.removeAll { $0.sceneEntityId == "scene.b" }
+        shortcuts.removeAll { $0.keyCode == keyCode && $0.modifiers == modifiers }
+        shortcuts.append(KeyboardShortcutConfig(keyCode: keyCode, modifiers: modifiers, sceneEntityId: "scene.b"))
+        settings.keyboardShortcuts = shortcuts
+
+        // scene.a's shortcut should be gone, only scene.b remains
+        XCTAssertEqual(settings.keyboardShortcuts.count, 1)
+        XCTAssertEqual(settings.keyboardShortcuts[0].sceneEntityId, "scene.b")
+    }
+
     func testDefaultURLPrePopulated() {
         // The default URL should be pre-populated (not empty)
         let settings = AppSettings.shared


### PR DESCRIPTION
## Summary

- When recording a shortcut, any other scene with the same `(keyCode, modifiers)` combo is now automatically cleared before saving
- Prevents silent shadowing where only the first registered shortcut fires
- Matches macOS System Settings conflict resolution behavior
- 1 new test verifying duplicate resolution

Fixes #14

## Test plan

- [ ] Assign ⌘⇧B to Scene A, then assign ⌘⇧B to Scene B → Scene A's shortcut cleared, Scene B works
- [ ] Assign unique shortcuts to multiple scenes → all work independently
- [ ] 130 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)