### PR TITLE
Show Focus Mode availability status in Triggers tab

### DIFF
--- a/BusyLight/Services/FocusModeMonitor.swift
+++ b/BusyLight/Services/FocusModeMonitor.swift
@@ -12,7 +12,7 @@ final class FocusModeMonitor {
     private(set) var isFocusActive = false
     private var pollingTimer: Timer?
     private var isMonitoring = false
-    private var isAvailable = true
+    private(set) var isAvailable = true
 
     func startMonitoring() {
         guard !isMonitoring else { return }

--- a/BusyLight/Views/Settings/TriggersTab.swift
+++ b/BusyLight/Views/Settings/TriggersTab.swift
@@ -50,15 +50,23 @@ struct TriggersTab: View {
                     isEnabled: $settings.focusOnTriggerEnabled,
                     sceneId: $settings.focusOnSceneId
                 )
+                .disabled(!FocusModeMonitor.shared.isAvailable)
                 triggerRow(
                     label: "Enable scene when Focus mode deactivated:",
                     isEnabled: $settings.focusOffTriggerEnabled,
                     sceneId: $settings.focusOffSceneId
                 )
+                .disabled(!FocusModeMonitor.shared.isAvailable)
 
-                Text("Focus mode detection is experimental and may not work on all macOS versions.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                if FocusModeMonitor.shared.isAvailable {
+                    Text("Focus mode detection is experimental and may not work on all macOS versions.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("Focus mode detection is not available on this version of macOS.")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
             }
         }
         .formStyle(.grouped)


### PR DESCRIPTION
## Summary

- Exposed `FocusModeMonitor.isAvailable` as `private(set)` so the UI can read it
- Focus Mode trigger rows are now disabled when detection is unavailable
- Caption dynamically switches between "experimental" (available) and "not available on this version of macOS" (unavailable, in red)

Fixes #15

## Test plan

- [ ] On system with Focus Mode detection working: controls enabled, experimental caption shown
- [ ] On system without `~/Library/DoNotDisturb/DB/Assertions.json`: controls disabled, red "not available" message
- [ ] 130 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)