### PR TITLE
Replace camera/mic polling with property listener callbacks

### DIFF
--- a/BusyLight/Services/CameraMonitor.swift
+++ b/BusyLight/Services/CameraMonitor.swift
@@ -11,8 +11,14 @@ final class CameraMonitor {
     static let shared = CameraMonitor()
 
     private(set) var isCameraOn = false
-    private var pollingTimer: Timer?
     private var isMonitoring = false
+
+    /// Blocks registered with CMIOObjectAddPropertyListenerBlock, keyed by device ID.
+    /// Stored so we can pass the same reference to the remove call.
+    private var deviceListenerBlocks: [CMIOObjectID: CMIOObjectPropertyListenerBlock] = [:]
+
+    /// Block registered for system device-list changes.
+    private var deviceListBlock: (CMIOObjectPropertyListenerBlock)?
 
     func startMonitoring() {
         guard !isMonitoring else { return }
@@ -31,19 +37,101 @@ final class CameraMonitor {
             UInt32(MemoryLayout<UInt32>.size), &allow
         )
 
-        pollingTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.checkCameraState()
-            }
-        }
+        registerDeviceListListener()
+        registerPerDeviceListeners()
         checkCameraState()
     }
 
     func stopMonitoring() {
-        pollingTimer?.invalidate()
-        pollingTimer = nil
+        removeAllListeners()
         isMonitoring = false
     }
+
+    // MARK: - Listeners
+
+    private func registerDeviceListListener() {
+        var address = CMIOObjectPropertyAddress(
+            mSelector: CMIOObjectPropertySelector(kCMIOHardwarePropertyDevices),
+            mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+            mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMain)
+        )
+
+        let block: CMIOObjectPropertyListenerBlock = { [weak self] _, _ in
+            Task { @MainActor in
+                self?.handleDeviceListChanged()
+            }
+        }
+        deviceListBlock = block
+
+        CMIOObjectAddPropertyListenerBlock(
+            CMIOObjectID(kCMIOObjectSystemObject),
+            &address,
+            DispatchQueue.main,
+            block
+        )
+    }
+
+    private func handleDeviceListChanged() {
+        removePerDeviceListeners()
+        registerPerDeviceListeners()
+        checkCameraState()
+    }
+
+    private func registerPerDeviceListeners() {
+        let devices = enumerateDevices()
+
+        for device in devices {
+            var runningProp = CMIOObjectPropertyAddress(
+                mSelector: CMIOObjectPropertySelector(kCMIODevicePropertyDeviceIsRunningSomewhere),
+                mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+                mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMain)
+            )
+
+            let block: CMIOObjectPropertyListenerBlock = { [weak self] _, _ in
+                Task { @MainActor in
+                    self?.checkCameraState()
+                }
+            }
+            deviceListenerBlocks[device] = block
+
+            CMIOObjectAddPropertyListenerBlock(
+                device, &runningProp, DispatchQueue.main, block
+            )
+        }
+    }
+
+    private func removePerDeviceListeners() {
+        for (device, block) in deviceListenerBlocks {
+            var runningProp = CMIOObjectPropertyAddress(
+                mSelector: CMIOObjectPropertySelector(kCMIODevicePropertyDeviceIsRunningSomewhere),
+                mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+                mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMain)
+            )
+            CMIOObjectRemovePropertyListenerBlock(
+                device, &runningProp, DispatchQueue.main, block
+            )
+        }
+        deviceListenerBlocks.removeAll()
+    }
+
+    private func removeAllListeners() {
+        removePerDeviceListeners()
+
+        if let block = deviceListBlock {
+            var address = CMIOObjectPropertyAddress(
+                mSelector: CMIOObjectPropertySelector(kCMIOHardwarePropertyDevices),
+                mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+                mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMain)
+            )
+            CMIOObjectRemovePropertyListenerBlock(
+                CMIOObjectID(kCMIOObjectSystemObject),
+                &address, DispatchQueue.main, block
+            )
+            deviceListBlock = nil
+        }
+    }
+
+    // MARK: - State Check
 
     private func checkCameraState() {
         let wasOn = isCameraOn
@@ -58,6 +146,32 @@ final class CameraMonitor {
     }
 
     private func isAnyCameraRunning() -> Bool {
+        let devices = enumerateDevices()
+
+        for device in devices {
+            var isRunning: UInt32 = 0
+            var runningDataSize = UInt32(MemoryLayout<UInt32>.size)
+            var runningProp = CMIOObjectPropertyAddress(
+                mSelector: CMIOObjectPropertySelector(kCMIODevicePropertyDeviceIsRunningSomewhere),
+                mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
+                mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMain)
+            )
+
+            let status = CMIOObjectGetPropertyData(
+                device, &runningProp, 0, nil,
+                runningDataSize, &runningDataSize, &isRunning
+            )
+
+            if status == kCMIOHardwareNoError && isRunning == 1 {
+                return true
+            }
+        }
+        return false
+    }
+
+    // MARK: - Device Enumeration
+
+    private func enumerateDevices() -> [CMIOObjectID] {
         var dataSize: UInt32 = 0
         var devicesProp = CMIOObjectPropertyAddress(
             mSelector: CMIOObjectPropertySelector(kCMIOHardwarePropertyDevices),
@@ -69,7 +183,7 @@ final class CameraMonitor {
             CMIOObjectID(kCMIOObjectSystemObject),
             &devicesProp, 0, nil, &dataSize
         )
-        guard status == kCMIOHardwareNoError, dataSize > 0 else { return false }
+        guard status == kCMIOHardwareNoError, dataSize > 0 else { return [] }
 
         let deviceCount = Int(dataSize) / MemoryLayout<CMIOObjectID>.size
         var devices = [CMIOObjectID](repeating: 0, count: deviceCount)
@@ -78,26 +192,8 @@ final class CameraMonitor {
             &devicesProp, 0, nil,
             dataSize, &dataSize, &devices
         )
-        guard status == kCMIOHardwareNoError else { return false }
+        guard status == kCMIOHardwareNoError else { return [] }
 
-        for device in devices {
-            var isRunning: UInt32 = 0
-            var runningDataSize = UInt32(MemoryLayout<UInt32>.size)
-            var runningProp = CMIOObjectPropertyAddress(
-                mSelector: CMIOObjectPropertySelector(kCMIODevicePropertyDeviceIsRunningSomewhere),
-                mScope: CMIOObjectPropertyScope(kCMIOObjectPropertyScopeGlobal),
-                mElement: CMIOObjectPropertyElement(kCMIOObjectPropertyElementMain)
-            )
-
-            let runStatus = CMIOObjectGetPropertyData(
-                device, &runningProp, 0, nil,
-                runningDataSize, &runningDataSize, &isRunning
-            )
-
-            if runStatus == kCMIOHardwareNoError && isRunning == 1 {
-                return true
-            }
-        }
-        return false
+        return devices
     }
 }

--- a/BusyLight/Services/FocusModeMonitor.swift
+++ b/BusyLight/Services/FocusModeMonitor.swift
@@ -18,7 +18,7 @@ final class FocusModeMonitor {
         guard !isMonitoring else { return }
         isMonitoring = true
 
-        pollingTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+        pollingTimer = Timer.scheduledTimer(withTimeInterval: 15.0, repeats: true) { [weak self] _ in
             Task { @MainActor in
                 self?.checkFocusState()
             }

--- a/BusyLight/Services/MicrophoneMonitor.swift
+++ b/BusyLight/Services/MicrophoneMonitor.swift
@@ -11,26 +11,113 @@ final class MicrophoneMonitor {
     static let shared = MicrophoneMonitor()
 
     private(set) var isMicrophoneOn = false
-    private var pollingTimer: Timer?
     private var isMonitoring = false
+
+    /// Blocks registered per device for input-running changes, keyed by device ID.
+    private var deviceListenerBlocks: [AudioDeviceID: AudioObjectPropertyListenerBlock] = [:]
+
+    /// Block registered for system device-list changes.
+    private var deviceListBlock: AudioObjectPropertyListenerBlock?
 
     func startMonitoring() {
         guard !isMonitoring else { return }
         isMonitoring = true
 
-        pollingTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.checkMicState()
-            }
-        }
+        registerDeviceListListener()
+        registerPerDeviceListeners()
         checkMicState()
     }
 
     func stopMonitoring() {
-        pollingTimer?.invalidate()
-        pollingTimer = nil
+        removeAllListeners()
         isMonitoring = false
     }
+
+    // MARK: - Listeners
+
+    private func registerDeviceListListener() {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+            Task { @MainActor in
+                self?.handleDeviceListChanged()
+            }
+        }
+        deviceListBlock = block
+
+        AudioObjectAddPropertyListenerBlock(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            DispatchQueue.main,
+            block
+        )
+    }
+
+    private func handleDeviceListChanged() {
+        removePerDeviceListeners()
+        registerPerDeviceListeners()
+        checkMicState()
+    }
+
+    private func registerPerDeviceListeners() {
+        let devices = enumerateInputDevices()
+
+        for device in devices {
+            var runningAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+                mScope: kAudioObjectPropertyScopeInput,
+                mElement: kAudioObjectPropertyElementMain
+            )
+
+            let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
+                Task { @MainActor in
+                    self?.checkMicState()
+                }
+            }
+            deviceListenerBlocks[device] = block
+
+            AudioObjectAddPropertyListenerBlock(
+                device, &runningAddress, DispatchQueue.main, block
+            )
+        }
+    }
+
+    private func removePerDeviceListeners() {
+        for (device, block) in deviceListenerBlocks {
+            var runningAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+                mScope: kAudioObjectPropertyScopeInput,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            AudioObjectRemovePropertyListenerBlock(
+                device, &runningAddress, DispatchQueue.main, block
+            )
+        }
+        deviceListenerBlocks.removeAll()
+    }
+
+    private func removeAllListeners() {
+        removePerDeviceListeners()
+
+        if let block = deviceListBlock {
+            var address = AudioObjectPropertyAddress(
+                mSelector: kAudioHardwarePropertyDevices,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            AudioObjectRemovePropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject),
+                &address, DispatchQueue.main, block
+            )
+            deviceListBlock = nil
+        }
+    }
+
+    // MARK: - State Check
 
     private func checkMicState() {
         let wasOn = isMicrophoneOn
@@ -45,7 +132,32 @@ final class MicrophoneMonitor {
     }
 
     private func isAnyMicRunning() -> Bool {
-        // Get all audio devices
+        let devices = enumerateInputDevices()
+
+        for device in devices {
+            var isRunning: UInt32 = 0
+            var runningSize = UInt32(MemoryLayout<UInt32>.size)
+            var runningAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
+                mScope: kAudioObjectPropertyScopeInput,
+                mElement: kAudioObjectPropertyElementMain
+            )
+
+            let status = AudioObjectGetPropertyData(
+                device, &runningAddress, 0, nil, &runningSize, &isRunning
+            )
+
+            if status == noErr && isRunning == 1 {
+                return true
+            }
+        }
+        return false
+    }
+
+    // MARK: - Device Enumeration
+
+    /// Returns all audio devices that have at least one input stream.
+    private func enumerateInputDevices() -> [AudioDeviceID] {
         var propertySize: UInt32 = 0
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDevices,
@@ -57,7 +169,7 @@ final class MicrophoneMonitor {
             AudioObjectID(kAudioObjectSystemObject),
             &address, 0, nil, &propertySize
         )
-        guard status == noErr, propertySize > 0 else { return false }
+        guard status == noErr, propertySize > 0 else { return [] }
 
         let deviceCount = Int(propertySize) / MemoryLayout<AudioDeviceID>.size
         var devices = [AudioDeviceID](repeating: 0, count: deviceCount)
@@ -65,37 +177,18 @@ final class MicrophoneMonitor {
             AudioObjectID(kAudioObjectSystemObject),
             &address, 0, nil, &propertySize, &devices
         )
-        guard status == noErr else { return false }
+        guard status == noErr else { return [] }
 
-        for device in devices {
-            // Check if device has input streams (is a microphone)
+        // Filter to devices with input streams
+        return devices.filter { device in
             var inputStreamSize: UInt32 = 0
             var inputAddress = AudioObjectPropertyAddress(
                 mSelector: kAudioDevicePropertyStreams,
                 mScope: kAudioObjectPropertyScopeInput,
                 mElement: kAudioObjectPropertyElementMain
             )
-
-            status = AudioObjectGetPropertyDataSize(device, &inputAddress, 0, nil, &inputStreamSize)
-            guard status == noErr, inputStreamSize > 0 else { continue }
-
-            // Check if this input device is running
-            var isRunning: UInt32 = 0
-            var runningSize = UInt32(MemoryLayout<UInt32>.size)
-            var runningAddress = AudioObjectPropertyAddress(
-                mSelector: kAudioDevicePropertyDeviceIsRunningSomewhere,
-                mScope: kAudioObjectPropertyScopeInput,
-                mElement: kAudioObjectPropertyElementMain
-            )
-
-            let runStatus = AudioObjectGetPropertyData(
-                device, &runningAddress, 0, nil, &runningSize, &isRunning
-            )
-
-            if runStatus == noErr && isRunning == 1 {
-                return true
-            }
+            let s = AudioObjectGetPropertyDataSize(device, &inputAddress, 0, nil, &inputStreamSize)
+            return s == noErr && inputStreamSize > 0
         }
-        return false
     }
 }


### PR DESCRIPTION
## Summary

- **CameraMonitor**: Replaced 2s polling timer with `CMIOObjectAddPropertyListenerBlock` per-device listeners + system device-list listener for hot-plug
- **MicrophoneMonitor**: Replaced 2s polling timer with `AudioObjectAddPropertyListenerBlock` per-device listeners (input-scoped) + system device-list listener
- **FocusModeMonitor**: Increased polling interval from 5s to 15s (no callback API for file-based detection)
- Zero energy cost when idle — callbacks fire only on actual state changes
- Device hot-plug handled: system listener re-registers per-device listeners when devices are added/removed

Fixes #16

## Test plan

- [ ] Start a FaceTime/Zoom call → camera trigger fires immediately
- [ ] Plug in USB mic while running → detected and monitored
- [ ] Unplug USB camera → no crash, state updates correctly
- [ ] Activity Monitor shows no periodic wake-ups when idle
- [ ] 130 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)