### PR TITLE
Use minimum height for Settings window

### DIFF
--- a/BusyLight/Views/Settings/SettingsView.swift
+++ b/BusyLight/Views/Settings/SettingsView.swift
@@ -18,7 +18,7 @@ struct SettingsView: View {
                 .tabItem { Label("General", systemImage: "gear") }
                 .tag("general")
         }
-        .frame(width: 600, height: 500)
+        .frame(minWidth: 600, idealWidth: 600, minHeight: 500)
         .onReceive(NotificationCenter.default.publisher(for: .openSettingsRequest)) { notification in
             if let tab = notification.userInfo?["tab"] as? String {
                 selectedTab = tab


### PR DESCRIPTION
## Summary

- Changed Settings window frame from fixed `600×500` to `minWidth: 600, idealWidth: 600, minHeight: 500`
- Window can now grow vertically to accommodate larger Dynamic Type / accessibility text sizes

Fixes #18

## Test plan

- [ ] Settings window opens at normal size (600×500)
- [ ] Increase text size in System Settings → window grows to fit
- [ ] All tabs render without clipping
- [ ] 130 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)