### PR TITLE
Reset hotkey ID counter on unregisterAll()

### DIFF
--- a/BusyLight/Services/GlobalHotkeyManager.swift
+++ b/BusyLight/Services/GlobalHotkeyManager.swift
@@ -101,6 +101,7 @@ final class GlobalHotkeyManager {
         hotKeyRefs.removeAll()
         shortcutsByHotKeyId.removeAll()
         registeredShortcuts.removeAll()
+        nextHotKeyId = 1
     }
 
     // MARK: - Carbon dispatch


### PR DESCRIPTION
## Summary
- Resets `nextHotKeyId` to 1 in `GlobalHotkeyManager.unregisterAll()` so the counter doesn't grow unbounded across shortcut update cycles

Fixes #20

## Test plan
- [x] 130 tests pass, 0 failures
- [x] Verified `unregisterAll()` now resets `nextHotKeyId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)