### PR TITLE
Remove mismatched AppleScript properties and commands

### DIFF
--- a/BusyLight/BusyLight.sdef
+++ b/BusyLight/BusyLight.sdef
@@ -16,10 +16,6 @@
             <result type="text" description="Confirmation message on success."/>
         </command>
 
-        <command name="deactivate scene" code="BsLtDact" description="Deactivate the current scene (set to No Scene).">
-            <cocoa class="BusyLight.DeactivateSceneCommand"/>
-        </command>
-
         <command name="list scenes" code="BsLtLsSc" description="List all configured scenes.">
             <cocoa class="BusyLight.ListScenesCommand"/>
             <result>
@@ -35,25 +31,11 @@
                 <cocoa key="currentSceneName"/>
             </property>
 
-            <property name="is busy" code="BsBz" type="boolean" access="r"
-                      description="Whether a scene is currently active (true if any scene is active).">
-                <cocoa key="isBusy"/>
-            </property>
-
             <property name="display mode" code="BsDm" type="text" access="rw"
                       description="Menu bar display mode: 'emoji', 'name', or 'both'.">
                 <cocoa key="scriptDisplayMode"/>
             </property>
 
-            <property name="camera active" code="BsCa" type="boolean" access="r"
-                      description="Whether any camera is currently in use.">
-                <cocoa key="isCameraActive"/>
-            </property>
-
-            <property name="microphone active" code="BsMa" type="boolean" access="r"
-                      description="Whether any microphone is currently in use.">
-                <cocoa key="isMicrophoneActive"/>
-            </property>
         </class>
 
     </suite>

--- a/BusyLight/Scripting/ScriptCommands.swift
+++ b/BusyLight/Scripting/ScriptCommands.swift
@@ -30,16 +30,6 @@ class ActivateSceneCommand: NSScriptCommand {
     }
 }
 
-@objc(DeactivateSceneCommand)
-class DeactivateSceneCommand: NSScriptCommand {
-    override func performDefaultImplementation() -> Any? {
-        Task { @MainActor in
-            MenuBarManager.shared.deactivateScene()
-        }
-        return nil
-    }
-}
-
 @objc(ListScenesCommand)
 class ListScenesCommand: NSScriptCommand {
     @MainActor

--- a/BusyLight/Scripting/ScriptableApp.swift
+++ b/BusyLight/Scripting/ScriptableApp.swift
@@ -17,11 +17,6 @@ class ScriptableApp: NSApplication {
     }
 
     @MainActor
-    @objc var isBusy: Bool {
-        AppSettings.shared.activeSceneId != nil
-    }
-
-    @MainActor
     @objc var scriptDisplayMode: String {
         get {
             AppSettings.shared.displayMode.rawValue
@@ -34,13 +29,4 @@ class ScriptableApp: NSApplication {
         }
     }
 
-    @MainActor
-    @objc var isCameraActive: Bool {
-        CameraMonitor.shared.isCameraOn
-    }
-
-    @MainActor
-    @objc var isMicrophoneActive: Bool {
-        MicrophoneMonitor.shared.isMicrophoneOn
-    }
 }

--- a/README.md
+++ b/README.md
@@ -132,15 +132,12 @@ tell application "Busy Light"
 
     -- Check current state
     get current scene        -- returns entity ID or ""
-    get is busy              -- returns true/false
-    get camera active        -- returns true/false
-    get microphone active    -- returns true/false
+
+    -- Deactivate (set current scene to empty string)
+    set current scene to ""
 
     -- Change display mode
     set display mode to "emoji"  -- "emoji", "name", or "both"
-
-    -- Deactivate
-    deactivate scene
 
     -- List configured scenes
     list scenes


### PR DESCRIPTION
## Summary
- Removes `is busy`, `camera active`, `microphone active` properties from SDEF — don't match app UI/purpose
- Removes `deactivate scene` command from SDEF — no UI equivalent; users set `current scene` to `""` instead
- Updates README AppleScript examples accordingly
- Keeps `DeactivateSceneIntent` in Shortcuts.app and `MenuBarManager.deactivateScene()` for internal use

Fixes #28

## Test plan
- [x] 132 tests pass, 0 failures
- [x] No build warnings from SDEF changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)