### PR TITLE
Add MCP artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ Package.resolved
 
 # Claude
 .claude/
+
+# MCP artifacts
+entities.json
+mempalace.yaml


### PR DESCRIPTION
## Summary
- Adds `entities.json` and `mempalace.yaml` to `.gitignore` to prevent accidental commits of MCP artifacts

Fixes #23

## Test plan
- [x] Verified files are now ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)