### PR TITLE
Add CONTRIBUTING.md and SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to Busy Light
+
+Thanks for your interest in contributing! This is a small, single-maintainer project, so the process is lightweight.
+
+## Development Setup
+
+1. Install [XcodeGen](https://github.com/yonaskolb/XcodeGen): `brew install xcodegen`
+2. Generate the Xcode project: `xcodegen generate`
+3. Open `BusyLight.xcodeproj` in Xcode, or build from the command line:
+
+```bash
+xcodebuild -project BusyLight.xcodeproj -scheme BusyLight build
+```
+
+Run tests:
+
+```bash
+xcodebuild test -project BusyLight.xcodeproj -scheme BusyLight -destination 'platform=macOS'
+```
+
+## Requirements
+
+- **Swift 6** with strict concurrency enabled
+- **macOS 14.0** minimum deployment target
+- No third-party dependencies without prior discussion
+
+## Submitting Changes
+
+1. Open an issue first to discuss what you'd like to change.
+2. Fork the repo and create a branch from `main`.
+3. Make your changes, keeping commits focused and well-described.
+4. Ensure all tests pass before opening a PR.
+5. Reference the related issue in your PR description.
+
+## Code Style
+
+The existing codebase is the style guide. Key patterns:
+
+- `@MainActor` on all UI and `@Observable` classes
+- `async`/`await` over closure-based APIs
+- SwiftUI for the Settings window, AppKit for the menu bar
+- No force unwraps or force `try` unless truly unrecoverable
+
+## Questions?
+
+Open an issue if anything is unclear. Contributions of all sizes are welcome.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Busy Light, please report it responsibly.
+
+**Do not open a public issue.** Instead, use one of these methods:
+
+- **GitHub:** [Open a private security advisory](https://github.com/swizzlevixen/busylight/security/advisories/new)
+- **Email:** Contact the maintainer at the email address listed on their [GitHub profile](https://github.com/swizzlevixen)
+
+## What Qualifies
+
+Examples of security concerns for this project:
+
+- Home Assistant access token exposure (logging, crash reports, export)
+- Keychain data leakage
+- Code injection via malformed Home Assistant API responses
+- Arbitrary code execution through AppleScript or Shortcuts interfaces
+
+## What to Include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if you have one)
+
+## Response Timeline
+
+This is a single-maintainer project. I'll aim to acknowledge reports within 7 days and provide a fix or mitigation plan within 30 days, but timelines may vary.
+
+## Supported Versions
+
+Only the latest release is actively supported with security fixes.


### PR DESCRIPTION
## Summary
- **CONTRIBUTING.md**: Development setup (XcodeGen, build, test), Swift 6 requirements, PR guidelines, code style expectations
- **SECURITY.md**: Responsible disclosure via GitHub private advisory or email, what qualifies, response timeline

Fixes #24

## Test plan
- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)