### PR TITLE
Code review cleanup: deployment target, stale docs, API violations

### DIFF
--- a/BusyLight/BusyLight.help/Contents/Resources/en.lproj/using-triggers.html
+++ b/BusyLight/BusyLight.help/Contents/Resources/en.lproj/using-triggers.html
@@ -64,8 +64,8 @@
 
     <div class="note">
         Triggers work in the background regardless of which app is in the
-        foreground. The webcam and microphone monitors check the device status
-        every two seconds.
+        foreground. The webcam and microphone monitors respond to device
+        status changes in real time using system event callbacks.
     </div>
 </body>
 </html>

--- a/BusyLight/Services/HomeAssistantService.swift
+++ b/BusyLight/Services/HomeAssistantService.swift
@@ -165,7 +165,7 @@ actor HomeAssistantService {
         token: String, body: Data? = nil, maxRetries: Int = 3
     ) async throws -> Data {
         var lastError: (any Error)?
-        var delay: UInt64 = 1_000_000_000 // 1 second
+        var delay: Duration = .seconds(1)
 
         for attempt in 0..<maxRetries {
             do {
@@ -175,7 +175,7 @@ actor HomeAssistantService {
                 case .networkError, .serverError(500..., _):
                     lastError = error
                     if attempt < maxRetries - 1 {
-                        try? await Task.sleep(nanoseconds: delay)
+                        try? await Task.sleep(for: delay)
                         delay *= 2
                     }
                 default:

--- a/BusyLight/Views/Settings/SettingsView.swift
+++ b/BusyLight/Views/Settings/SettingsView.swift
@@ -5,18 +5,18 @@ struct SettingsView: View {
 
     var body: some View {
         TabView(selection: $selectedTab) {
-            HomeAssistantTab()
-                .tabItem { Label("Home Assistant", systemImage: "house") }
-                .tag("homeassistant")
-            ScenesTab()
-                .tabItem { Label("Scenes", systemImage: "theatermasks") }
-                .tag("scenes")
-            TriggersTab()
-                .tabItem { Label("Triggers", systemImage: "bolt.fill") }
-                .tag("triggers")
-            GeneralTab()
-                .tabItem { Label("General", systemImage: "gear") }
-                .tag("general")
+            Tab("Home Assistant", systemImage: "house", value: "homeassistant") {
+                HomeAssistantTab()
+            }
+            Tab("Scenes", systemImage: "theatermasks", value: "scenes") {
+                ScenesTab()
+            }
+            Tab("Triggers", systemImage: "bolt.fill", value: "triggers") {
+                TriggersTab()
+            }
+            Tab("General", systemImage: "gear", value: "general") {
+                GeneralTab()
+            }
         }
         .frame(minWidth: 600, idealWidth: 600, minHeight: 500)
         .onReceive(NotificationCenter.default.publisher(for: .openSettingsRequest)) { notification in

--- a/BusyLight/Views/Settings/SettingsView.swift
+++ b/BusyLight/Views/Settings/SettingsView.swift
@@ -4,19 +4,20 @@ struct SettingsView: View {
     @State private var selectedTab: String = "homeassistant"
 
     var body: some View {
+        // Tab API requires macOS 15; using tabItem() for macOS 14 compatibility.
         TabView(selection: $selectedTab) {
-            Tab("Home Assistant", systemImage: "house", value: "homeassistant") {
-                HomeAssistantTab()
-            }
-            Tab("Scenes", systemImage: "theatermasks", value: "scenes") {
-                ScenesTab()
-            }
-            Tab("Triggers", systemImage: "bolt.fill", value: "triggers") {
-                TriggersTab()
-            }
-            Tab("General", systemImage: "gear", value: "general") {
-                GeneralTab()
-            }
+            HomeAssistantTab()
+                .tabItem { Label("Home Assistant", systemImage: "house") }
+                .tag("homeassistant")
+            ScenesTab()
+                .tabItem { Label("Scenes", systemImage: "theatermasks") }
+                .tag("scenes")
+            TriggersTab()
+                .tabItem { Label("Triggers", systemImage: "bolt.fill") }
+                .tag("triggers")
+            GeneralTab()
+                .tabItem { Label("General", systemImage: "gear") }
+                .tag("general")
         }
         .frame(minWidth: 600, idealWidth: 600, minHeight: 500)
         .onReceive(NotificationCenter.default.publisher(for: .openSettingsRequest)) { notification in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ macOS menu bar application that connects to Home Assistant to trigger scenes, pr
 - **Language**: Swift 6
 - **UI**: Hybrid AppKit (menu bar via NSStatusItem/NSMenu) + SwiftUI (Settings window)
 - **Frameworks**: CoreMediaIO (camera detection), CoreAudio (mic detection), ServiceManagement (launch at login), AppIntents (Shortcuts.app), Security (Keychain)
-- **Minimum Deployment**: macOS 15.0
+- **Minimum Deployment**: macOS 14.0
 - **Distribution**: Non-sandboxed (outside App Store)
 - **Project Generation**: XcodeGen (`project.yml` → `BusyLight.xcodeproj`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ macOS menu bar application that connects to Home Assistant to trigger scenes, pr
 - **Language**: Swift 6
 - **UI**: Hybrid AppKit (menu bar via NSStatusItem/NSMenu) + SwiftUI (Settings window)
 - **Frameworks**: CoreMediaIO (camera detection), CoreAudio (mic detection), ServiceManagement (launch at login), AppIntents (Shortcuts.app), Security (Keychain)
-- **Minimum Deployment**: macOS 14.0
+- **Minimum Deployment**: macOS 15.0
 - **Distribution**: Non-sandboxed (outside App Store)
 - **Project Generation**: XcodeGen (`project.yml` → `BusyLight.xcodeproj`)
 
@@ -45,12 +45,12 @@ xcodebuild test -project BusyLight.xcodeproj -scheme BusyLight -destination 'pla
 
 ### Services
 - `HomeAssistantService`: Actor with async/await REST API client, exponential backoff retry, connection health checks
-- `CameraMonitor`: CoreMediaIO `kCMIODevicePropertyDeviceIsRunningSomewhere` (2s polling)
-- `MicrophoneMonitor`: CoreAudio `kAudioDevicePropertyDeviceIsRunningSomewhere` (2s polling)
+- `CameraMonitor`: CoreMediaIO `CMIOObjectAddPropertyListenerBlock` event-driven monitoring
+- `MicrophoneMonitor`: CoreAudio `AudioObjectAddPropertyListenerBlock` event-driven monitoring
 - `ScreenLockMonitor`: `DistributedNotificationCenter` for lock/unlock, `NSWorkspace` for sleep
-- `FocusModeMonitor`: Reads `~/Library/DoNotDisturb/DB/Assertions.json` (5s polling, experimental)
-- `GlobalHotkeyManager`: `NSEvent.addGlobalMonitorForEvents` for system-wide keyboard shortcuts
-- `TriggerManager`: Coordinates all monitors, applies trigger settings, camera > mic priority
+- `FocusModeMonitor`: Reads `~/Library/DoNotDisturb/DB/Assertions.json` (15s polling, experimental)
+- `GlobalHotkeyManager`: Carbon `RegisterEventHotKey` for system-wide keyboard shortcuts
+- `TriggerManager`: Coordinates all monitors, applies trigger settings, camera > mic priority, error notifications
 
 ### Automation
 - AppleScript via SDEF (`BusyLight.sdef`) + `ScriptableApp` (NSApplication subclass) + `NSScriptCommand` subclasses
@@ -68,7 +68,7 @@ xcodebuild test -project BusyLight.xcodeproj -scheme BusyLight -destination 'pla
 - `BusyLight/BusyLight.sdef` - AppleScript dictionary
 - `BusyLight/AppDelegate.swift` - Menu bar NSStatusItem + NSMenuDelegate + first-run dialog
 - `BusyLight/Services/HomeAssistantService.swift` - HA REST API client
-- `BusyLight/Services/TriggerManager.swift` - Monitor coordination + Revert Scene logic
+- `BusyLight/Services/TriggerManager.swift` - Monitor coordination + trigger settings
 - `BusyLight/Models/AppSettings.swift` - All settings persistence
 - `BusyLight/Views/Utility/EmojiPickerButton.swift` - System emoji picker component (NSViewRepresentable)
 - `BusyLight/Views/Utility/ShortcutRecorderView.swift` - Keyboard shortcut recorder component

--- a/project.yml
+++ b/project.yml
@@ -2,7 +2,7 @@ name: BusyLight
 options:
   bundleIdPrefix: com.mboszko
   deploymentTarget:
-    macOS: "14.0"
+    macOS: "15.0"
   xcodeVersion: "16.0"
   createIntermediateGroups: true
   generateEmptyDirectories: true
@@ -14,7 +14,7 @@ configs:
 settings:
   base:
     SWIFT_VERSION: "6.0"
-    MACOSX_DEPLOYMENT_TARGET: "14.0"
+    MACOSX_DEPLOYMENT_TARGET: "15.0"
     ENABLE_HARDENED_RUNTIME: YES
 
 targets:

--- a/project.yml
+++ b/project.yml
@@ -2,7 +2,7 @@ name: BusyLight
 options:
   bundleIdPrefix: com.mboszko
   deploymentTarget:
-    macOS: "15.0"
+    macOS: "14.0"
   xcodeVersion: "16.0"
   createIntermediateGroups: true
   generateEmptyDirectories: true
@@ -14,7 +14,7 @@ configs:
 settings:
   base:
     SWIFT_VERSION: "6.0"
-    MACOSX_DEPLOYMENT_TARGET: "15.0"
+    MACOSX_DEPLOYMENT_TARGET: "14.0"
     ENABLE_HARDENED_RUNTIME: YES
 
 targets:


### PR DESCRIPTION
## Summary
- **HomeAssistantService**: `Task.sleep(nanoseconds:)` → `Task.sleep(for:)` 
- **CLAUDE.md**: Updated CameraMonitor/MicrophoneMonitor (event-driven, not polling), GlobalHotkeyManager (Carbon, not NSEvent), FocusModeMonitor (15s), TriggerManager (removed "Revert Scene" reference)
- **Help book**: Updated trigger description from "every two seconds" to event-driven
- **SettingsView**: Added comment explaining `tabItem()` usage (Tab API requires macOS 15)

## Test plan
- [x] 132 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)