### PR TITLE
Non-blocking error display when HA is unreachable

### DIFF
--- a/BusyLight/BusyLightApp.swift
+++ b/BusyLight/BusyLightApp.swift
@@ -43,4 +43,5 @@ struct BusyLightApp: App {
 extension Notification.Name {
     static let openSettingsRequest = Notification.Name("BusyLight.openSettingsRequest")
     static let settingsWindowClosed = Notification.Name("BusyLight.settingsWindowClosed")
+    static let haConnectionStateChanged = Notification.Name("BusyLight.haConnectionStateChanged")
 }

--- a/BusyLight/Models/AppSettings.swift
+++ b/BusyLight/Models/AppSettings.swift
@@ -46,6 +46,17 @@ final class AppSettings {
         didSet { UserDefaults.standard.set(activeSceneId, forKey: "activeSceneId") }
     }
 
+    // MARK: - Connection State (runtime only, not persisted)
+
+    var connectionState: ConnectionState = .unknown
+
+    var isDisconnected: Bool {
+        switch connectionState {
+        case .disconnected, .error: return true
+        default: return false
+        }
+    }
+
     // MARK: - Trigger Settings
 
     var webcamTriggerEnabled: Bool {
@@ -120,12 +131,13 @@ final class AppSettings {
 
     /// Text shown in the menu bar, reflecting the active scene and display mode.
     var menuBarLabel: String {
+        let warning = isDisconnected ? " \u{26A0}\u{FE0F}" : ""
         if let activeId = activeSceneId,
            let scene = scenes.first(where: { $0.entityId == activeId }) {
             switch displayMode {
-            case .emojiOnly: return scene.emoji
-            case .nameOnly:  return scene.displayName
-            case .both:      return "\(scene.emoji) \(scene.displayName)"
+            case .emojiOnly: return scene.emoji + warning
+            case .nameOnly:  return scene.displayName + warning
+            case .both:      return "\(scene.emoji) \(scene.displayName)" + warning
             }
         }
         return noSceneLabel
@@ -133,10 +145,11 @@ final class AppSettings {
 
     /// Text shown when no scene is active, respecting the display mode setting.
     var noSceneLabel: String {
+        let warning = isDisconnected ? " \u{26A0}\u{FE0F}" : ""
         switch displayMode {
-        case .emojiOnly: return "\u{26AB}"
-        case .nameOnly:  return "No Scene"
-        case .both:      return "\u{26AB} No Scene"
+        case .emojiOnly: return "\u{26AB}" + warning
+        case .nameOnly:  return "No Scene" + warning
+        case .both:      return "\u{26AB} No Scene" + warning
         }
     }
 

--- a/BusyLight/Services/HomeAssistantService.swift
+++ b/BusyLight/Services/HomeAssistantService.swift
@@ -67,6 +67,18 @@ actor HomeAssistantService {
 
     private(set) var connectionState: ConnectionState = .unknown
 
+    /// Updates `connectionState` and posts a notification when the state changes.
+    /// Skips posting if the new state matches the current one.
+    private func setConnectionState(_ newState: ConnectionState) {
+        guard connectionState != newState else { return }
+        connectionState = newState
+        NotificationCenter.default.post(
+            name: .haConnectionStateChanged,
+            object: nil,
+            userInfo: ["state": newState]
+        )
+    }
+
     enum HAError: LocalizedError {
         case invalidURL
         case unauthorized
@@ -102,7 +114,7 @@ actor HomeAssistantService {
                 do {
                     _ = try await self.testConnection(baseURL: baseURL, token: token)
                 } catch {
-                    self.connectionState = .disconnected
+                    self.setConnectionState(.disconnected)
                 }
                 // Exit if a newer health check loop has started
                 guard myGeneration == self.healthCheckGeneration else { break }
@@ -124,7 +136,7 @@ actor HomeAssistantService {
         struct HealthResponse: Decodable { let message: String }
         let response = try JSONDecoder().decode(HealthResponse.self, from: data)
         let success = response.message == "API running."
-        connectionState = success ? .connected : .error("Unexpected response")
+        setConnectionState(success ? .connected : .error("Unexpected response"))
         return success
     }
 
@@ -209,7 +221,7 @@ actor HomeAssistantService {
         do {
             (data, response) = try await session.data(for: req)
         } catch {
-            connectionState = .disconnected
+            setConnectionState(.disconnected)
             throw HAError.networkError(error)
         }
 
@@ -219,7 +231,7 @@ actor HomeAssistantService {
 
         switch httpResponse.statusCode {
         case 200...299:
-            connectionState = .connected
+            setConnectionState(.connected)
             return data
         case 401:
             throw HAError.unauthorized

--- a/BusyLight/Services/TriggerManager.swift
+++ b/BusyLight/Services/TriggerManager.swift
@@ -63,6 +63,21 @@ final class TriggerManager {
             }
         )
 
+        // Bridge HA connection state to AppSettings for UI observation
+        observers.append(
+            NotificationCenter.default.addObserver(
+                forName: .haConnectionStateChanged, object: nil, queue: .main
+            ) { [weak self] notification in
+                guard let state = notification.userInfo?["state"] as? ConnectionState else { return }
+                Task { @MainActor in
+                    self?.settings.connectionState = state
+                }
+            }
+        )
+
+        // Request notification permission so trigger-failure alerts display
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+
         // Start HA health checks if configured
         if !settings.haBaseURL.isEmpty && !settings.haToken.isEmpty {
             Task {

--- a/BusyLight/ViewModels/MenuBarManager.swift
+++ b/BusyLight/ViewModels/MenuBarManager.swift
@@ -15,15 +15,22 @@ final class MenuBarManager {
     }
 
     /// Fire-and-forget activation by entity ID string.
+    /// Sets `activeSceneId` optimistically and reverts if the HA call fails.
     func activateScene(entityId: String) {
+        let previousId = settings.activeSceneId
         settings.activeSceneId = entityId
         guard !settings.haBaseURL.isEmpty && !settings.haToken.isEmpty else { return }
         Task {
-            await HomeAssistantService.shared.activateScene(
+            let result = await HomeAssistantService.shared.activateScene(
                 entityId: entityId,
                 baseURL: settings.haBaseURL,
                 token: settings.haToken
             )
+            if !result.success {
+                await MainActor.run {
+                    settings.activeSceneId = previousId
+                }
+            }
         }
     }
 

--- a/BusyLight/Views/MenuBar/MenuBarContentView.swift
+++ b/BusyLight/Views/MenuBar/MenuBarContentView.swift
@@ -41,6 +41,12 @@ struct MenuBarContentView: View {
 
     @ViewBuilder
     private var menuItems: some View {
+        // Connection warning (auto-clears when health check succeeds)
+        if settings.isDisconnected {
+            Text("\u{26A0}\u{FE0F} Unable to reach Home Assistant")
+            Divider()
+        }
+
         // Scene list or empty-state shortcut
         if settings.menuItems.isEmpty {
             Button { postOpen(tab: "scenes") } label: {

--- a/BusyLightTests/Services/ConnectionFeedbackTests.swift
+++ b/BusyLightTests/Services/ConnectionFeedbackTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+@testable import BusyLight
+
+// MARK: - AppSettings connection state tests
+
+@MainActor
+final class ConnectionFeedbackTests: XCTestCase {
+
+    private let scene = SceneItem(entityId: "scene.test", emoji: "🔴", displayName: "Busy")
+
+    override func setUp() {
+        super.setUp()
+        KeychainHelper.testStore = [:]
+        let settings = AppSettings.shared
+        settings.displayMode = .both
+        settings.menuItems = []
+        settings.activeSceneId = nil
+        settings.connectionState = .unknown
+    }
+
+    override func tearDown() {
+        AppSettings.shared.connectionState = .unknown
+        KeychainHelper.testStore = nil
+        super.tearDown()
+    }
+
+    // MARK: - isDisconnected
+
+    func testIsDisconnectedWhenUnknown() {
+        AppSettings.shared.connectionState = .unknown
+        XCTAssertFalse(AppSettings.shared.isDisconnected)
+    }
+
+    func testIsDisconnectedWhenConnected() {
+        AppSettings.shared.connectionState = .connected
+        XCTAssertFalse(AppSettings.shared.isDisconnected)
+    }
+
+    func testIsDisconnectedWhenDisconnected() {
+        AppSettings.shared.connectionState = .disconnected
+        XCTAssertTrue(AppSettings.shared.isDisconnected)
+    }
+
+    func testIsDisconnectedWhenError() {
+        AppSettings.shared.connectionState = .error("test error")
+        XCTAssertTrue(AppSettings.shared.isDisconnected)
+    }
+
+    // MARK: - Menu bar label with warning
+
+    func testMenuBarLabelNoWarningWhenConnected() {
+        AppSettings.shared.connectionState = .connected
+        AppSettings.shared.displayMode = .both
+        AppSettings.shared.activeSceneId = nil
+        XCTAssertEqual(AppSettings.shared.menuBarLabel, "⚫ No Scene")
+    }
+
+    func testMenuBarLabelWarningWhenDisconnected() {
+        AppSettings.shared.connectionState = .disconnected
+        AppSettings.shared.displayMode = .both
+        AppSettings.shared.activeSceneId = nil
+        XCTAssertTrue(AppSettings.shared.menuBarLabel.contains("⚠️"))
+    }
+
+    func testMenuBarLabelWarningWhenError() {
+        AppSettings.shared.connectionState = .error("timeout")
+        AppSettings.shared.displayMode = .both
+        AppSettings.shared.menuItems = [.scene(scene)]
+        AppSettings.shared.activeSceneId = scene.entityId
+        XCTAssertTrue(AppSettings.shared.menuBarLabel.contains("⚠️"))
+        XCTAssertTrue(AppSettings.shared.menuBarLabel.contains("🔴"))
+    }
+
+    func testNoSceneLabelWarningWhenDisconnected() {
+        AppSettings.shared.connectionState = .disconnected
+        AppSettings.shared.displayMode = .nameOnly
+        XCTAssertTrue(AppSettings.shared.noSceneLabel.contains("⚠️"))
+    }
+
+    func testNoSceneLabelNoWarningWhenConnected() {
+        AppSettings.shared.connectionState = .connected
+        AppSettings.shared.displayMode = .nameOnly
+        XCTAssertEqual(AppSettings.shared.noSceneLabel, "No Scene")
+    }
+
+    // MARK: - Warning clears on reconnect
+
+    func testWarningClearsWhenConnectionRestored() {
+        AppSettings.shared.connectionState = .disconnected
+        AppSettings.shared.displayMode = .both
+        XCTAssertTrue(AppSettings.shared.menuBarLabel.contains("⚠️"))
+
+        AppSettings.shared.connectionState = .connected
+        XCTAssertFalse(AppSettings.shared.menuBarLabel.contains("⚠️"))
+    }
+}
+
+// MARK: - HomeAssistantService notification tests
+
+final class ConnectionStateNotificationTests: XCTestCase {
+    var service: HomeAssistantService!
+    var session: URLSession!
+
+    override func setUp() {
+        super.setUp()
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        session = URLSession(configuration: config)
+        service = HomeAssistantService(session: session)
+    }
+
+    override func tearDown() {
+        MockURLProtocol.requestHandler = nil
+        super.tearDown()
+    }
+
+    func testNotificationPostedOnConnectionSuccess() async throws {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = #"{"message": "API running."}"#.data(using: .utf8)!
+            return (response, data)
+        }
+
+        let expectation = XCTNSNotificationExpectation(
+            name: .haConnectionStateChanged,
+            object: nil
+        )
+
+        _ = try await service.testConnection(baseURL: "http://localhost:8123", token: "token")
+
+        await fulfillment(of: [expectation], timeout: 2)
+    }
+
+    func testNotificationPostedOnNetworkError() async {
+        MockURLProtocol.requestHandler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let expectation = XCTNSNotificationExpectation(
+            name: .haConnectionStateChanged,
+            object: nil
+        )
+
+        _ = await service.activateScene(
+            entityId: "scene.test",
+            baseURL: "http://localhost:8123",
+            token: "token"
+        )
+
+        await fulfillment(of: [expectation], timeout: 2)
+    }
+
+    func testNoNotificationOnDuplicateState() async throws {
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let data = #"{"message": "API running."}"#.data(using: .utf8)!
+            return (response, data)
+        }
+
+        // First call sets state to .connected — should post
+        _ = try await service.testConnection(baseURL: "http://localhost:8123", token: "token")
+
+        // Second call with same state — should NOT post
+        let expectation = XCTNSNotificationExpectation(
+            name: .haConnectionStateChanged,
+            object: nil
+        )
+        expectation.isInverted = true
+
+        _ = try await service.testConnection(baseURL: "http://localhost:8123", token: "token")
+
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+}


### PR DESCRIPTION
Closes #75

## Summary
- **Menu bar warning**: Appends ⚠️ to the menu bar label when Home Assistant is unreachable, clears automatically when connection restores
- **Dropdown status row**: Shows "⚠️ Unable to reach Home Assistant" at the top of the menu when disconnected
- **Activation rollback**: Reverts optimistic `activeSceneId` when a menu-click scene activation fails (checkmark briefly appears then reverts)
- **Connection state bridge**: Propagates `connectionState` from `HomeAssistantService` (actor) to `AppSettings` (@Observable) via `NotificationCenter` for SwiftUI observation
- **Notification permission**: Requests `UNUserNotificationCenter` authorization at startup so existing trigger-failure alerts actually display

## Test plan
- [x] New tests: `ConnectionFeedbackTests` (10 tests) — `isDisconnected`, label warnings, auto-clear
- [x] New tests: `ConnectionStateNotificationTests` (3 tests) — notification posting, dedup
- [x] All existing tests pass unchanged
- [ ] Manual: Run with HA unreachable → verify ⚠️ in menu bar and status row in dropdown
- [ ] Manual: Click scene while disconnected → verify checkmark reverts
- [ ] Manual: Restore HA connection → verify warning clears within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)