### PR TITLE
Show app name in menu bar when no scene is active

### DIFF
--- a/BusyLight/Models/AppSettings.swift
+++ b/BusyLight/Models/AppSettings.swift
@@ -147,9 +147,9 @@ final class AppSettings {
     var noSceneLabel: String {
         let warning = isDisconnected ? " \u{26A0}\u{FE0F}" : ""
         switch displayMode {
-        case .emojiOnly: return "\u{26AB}" + warning
-        case .nameOnly:  return "No Scene" + warning
-        case .both:      return "\u{26AB} No Scene" + warning
+        case .emojiOnly: return "🚦" + warning
+        case .nameOnly:  return "Busy Light" + warning
+        case .both:      return "🚦 Busy Light" + warning
         }
     }
 

--- a/BusyLightTests/Services/ConnectionFeedbackTests.swift
+++ b/BusyLightTests/Services/ConnectionFeedbackTests.swift
@@ -52,7 +52,7 @@ final class ConnectionFeedbackTests: XCTestCase {
         AppSettings.shared.connectionState = .connected
         AppSettings.shared.displayMode = .both
         AppSettings.shared.activeSceneId = nil
-        XCTAssertEqual(AppSettings.shared.menuBarLabel, "⚫ No Scene")
+        XCTAssertEqual(AppSettings.shared.menuBarLabel, "🚦 Busy Light")
     }
 
     func testMenuBarLabelWarningWhenDisconnected() {
@@ -80,7 +80,7 @@ final class ConnectionFeedbackTests: XCTestCase {
     func testNoSceneLabelNoWarningWhenConnected() {
         AppSettings.shared.connectionState = .connected
         AppSettings.shared.displayMode = .nameOnly
-        XCTAssertEqual(AppSettings.shared.noSceneLabel, "No Scene")
+        XCTAssertEqual(AppSettings.shared.noSceneLabel, "Busy Light")
     }
 
     // MARK: - Warning clears on reconnect

--- a/BusyLightTests/ViewModels/MenuBarManagerTests.swift
+++ b/BusyLightTests/ViewModels/MenuBarManagerTests.swift
@@ -24,17 +24,17 @@ final class MenuBarManagerTests: XCTestCase {
 
     func testNoSceneLabelBoth() {
         AppSettings.shared.displayMode = .both
-        XCTAssertEqual(AppSettings.shared.noSceneLabel, "\u{26AB} No Scene")
+        XCTAssertEqual(AppSettings.shared.noSceneLabel, "🚦 Busy Light")
     }
 
     func testNoSceneLabelEmojiOnly() {
         AppSettings.shared.displayMode = .emojiOnly
-        XCTAssertEqual(AppSettings.shared.noSceneLabel, "\u{26AB}")
+        XCTAssertEqual(AppSettings.shared.noSceneLabel, "🚦")
     }
 
     func testNoSceneLabelNameOnly() {
         AppSettings.shared.displayMode = .nameOnly
-        XCTAssertEqual(AppSettings.shared.noSceneLabel, "No Scene")
+        XCTAssertEqual(AppSettings.shared.noSceneLabel, "Busy Light")
     }
 
     // MARK: - menuBarLabel (no active scene)
@@ -42,19 +42,19 @@ final class MenuBarManagerTests: XCTestCase {
     func testMenuBarLabelNoSceneBoth() {
         AppSettings.shared.displayMode = .both
         AppSettings.shared.activeSceneId = nil
-        XCTAssertEqual(AppSettings.shared.menuBarLabel, "\u{26AB} No Scene")
+        XCTAssertEqual(AppSettings.shared.menuBarLabel, "🚦 Busy Light")
     }
 
     func testMenuBarLabelNoSceneEmojiOnly() {
         AppSettings.shared.displayMode = .emojiOnly
         AppSettings.shared.activeSceneId = nil
-        XCTAssertEqual(AppSettings.shared.menuBarLabel, "\u{26AB}")
+        XCTAssertEqual(AppSettings.shared.menuBarLabel, "🚦")
     }
 
     func testMenuBarLabelNoSceneNameOnly() {
         AppSettings.shared.displayMode = .nameOnly
         AppSettings.shared.activeSceneId = nil
-        XCTAssertEqual(AppSettings.shared.menuBarLabel, "No Scene")
+        XCTAssertEqual(AppSettings.shared.menuBarLabel, "Busy Light")
     }
 
     // MARK: - menuBarLabel (with active scene)
@@ -86,7 +86,7 @@ final class MenuBarManagerTests: XCTestCase {
         AppSettings.shared.displayMode = .both
         AppSettings.shared.menuItems = [.scene(scene)]
         AppSettings.shared.activeSceneId = "scene.nonexistent"
-        XCTAssertEqual(AppSettings.shared.menuBarLabel, "\u{26AB} No Scene")
+        XCTAssertEqual(AppSettings.shared.menuBarLabel, "🚦 Busy Light")
     }
 
     // MARK: - MenuBarManager activation (SceneItem)
@@ -115,7 +115,7 @@ final class MenuBarManagerTests: XCTestCase {
         AppSettings.shared.menuItems = [.scene(scene)]
         AppSettings.shared.activeSceneId = scene.entityId
         MenuBarManager.shared.deactivateScene()
-        XCTAssertEqual(AppSettings.shared.menuBarLabel, "\u{26AB} No Scene")
+        XCTAssertEqual(AppSettings.shared.menuBarLabel, "🚦 Busy Light")
     }
 
     // MARK: - MenuBarManager activation (entityId)


### PR DESCRIPTION
## Summary
- Replaces "⚫ No Scene" with "🚦 Busy Light" as the default menu bar display when no scene is active
- Applies to first launch, deleted scenes, and empty scene lists
- Respects the emoji/name/both display mode setting

Closes #76

## Test plan
- [x] All `noSceneLabel` tests updated and passing
- [x] All `menuBarLabel` (no active scene) tests updated and passing
- [x] `ConnectionFeedbackTests` updated and passing
- [x] Verify emoji-only mode shows `🚦`
- [x] Verify name-only mode shows `Busy Light`
- [x] Verify both mode shows `🚦 Busy Light`

🤖 Generated with [Claude Code](https://claude.com/claude-code)