### PR TITLE
Remove deactivate scene from Shortcuts and AppleScript

### DIFF
--- a/BusyLight/BusyLight.sdef
+++ b/BusyLight/BusyLight.sdef
@@ -27,7 +27,7 @@
             <cocoa class="BusyLight.ScriptableApp"/>
 
             <property name="current scene" code="BsCu" type="text" access="rw"
-                      description="The entity ID of the currently active scene, or empty string if none.">
+                      description="The entity ID of the currently active scene (read), or a scene entity ID to activate (write).">
                 <cocoa key="currentSceneName"/>
             </property>
 

--- a/BusyLight/Scripting/AppIntents.swift
+++ b/BusyLight/Scripting/AppIntents.swift
@@ -23,20 +23,6 @@ struct ActivateSceneIntent: AppIntent {
     }
 }
 
-// MARK: - Deactivate Scene Intent
-
-struct DeactivateSceneIntent: AppIntent {
-    static let title: LocalizedStringResource = "Deactivate Scene"
-    static let description: IntentDescription = "Clear the active scene in Busy Light."
-    static let openAppWhenRun: Bool = false
-
-    @MainActor
-    func perform() async throws -> some IntentResult & ReturnsValue<String> {
-        MenuBarManager.shared.deactivateScene()
-        return .result(value: "Scene deactivated")
-    }
-}
-
 // MARK: - Get Current Scene Intent
 
 struct GetCurrentSceneIntent: AppIntent {
@@ -83,17 +69,6 @@ struct BusyLightShortcuts: AppShortcutsProvider {
             ],
             shortTitle: "Activate Scene",
             systemImageName: "light.beacon.max.fill"
-        )
-
-        AppShortcut(
-            intent: DeactivateSceneIntent(),
-            phrases: [
-                "Deactivate \(.applicationName) scene",
-                "Turn off \(.applicationName)",
-                "Clear \(.applicationName) scene",
-            ],
-            shortTitle: "Deactivate Scene",
-            systemImageName: "light.beacon.min"
         )
 
         AppShortcut(

--- a/BusyLight/Scripting/ScriptableApp.swift
+++ b/BusyLight/Scripting/ScriptableApp.swift
@@ -8,11 +8,8 @@ class ScriptableApp: NSApplication {
             AppSettings.shared.activeSceneId ?? ""
         }
         set {
-            if newValue.isEmpty {
-                MenuBarManager.shared.deactivateScene()
-            } else {
-                MenuBarManager.shared.activateScene(entityId: newValue)
-            }
+            guard !newValue.isEmpty else { return }
+            MenuBarManager.shared.activateScene(entityId: newValue)
         }
     }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ xcodebuild test -project BusyLight.xcodeproj -scheme BusyLight -destination 'pla
 
 ### Automation
 - AppleScript via SDEF (`BusyLight.sdef`) + `ScriptableApp` (NSApplication subclass) + `NSScriptCommand` subclasses
-- Shortcuts.app via AppIntents framework (`ActivateSceneIntent`, `DeactivateSceneIntent`, etc.)
+- Shortcuts.app via AppIntents framework (`ActivateSceneIntent`, `GetCurrentSceneIntent`, `ListScenesIntent`)
 
 ### Data
 - `SceneItem`: Codable model (id, entityId, emoji, displayName)

--- a/README.md
+++ b/README.md
@@ -97,9 +97,6 @@ tell application "Busy Light"
     -- Check current state
     get current scene        -- returns entity ID or ""
 
-    -- Deactivate (set current scene to empty string)
-    set current scene to ""
-
     -- Change display mode
     set display mode to "emoji"  -- "emoji", "name", or "both"
 
@@ -113,7 +110,6 @@ end tell
 The following actions are available in Shortcuts.app:
 
 - **Activate Scene** -- Trigger a Home Assistant scene
-- **Deactivate Scene** -- Clear the active scene
 - **Get Current Scene** -- Check what scene is active
 - **List Scenes** -- Get all configured scenes
 


### PR DESCRIPTION
## Summary
- Remove `DeactivateSceneIntent` and its AppShortcut registration (HA scenes are one-way)
- AppleScript `current scene` setter now ignores empty strings instead of deactivating
- Update SDEF property description to clarify activate-only behavior
- Update README.md and CLAUDE.md documentation

`MenuBarManager.deactivateScene()` is kept for the local keyboard shortcut toggle feature.

Closes #78

## Test plan
- [x] All existing tests pass (no test removals needed)
- [x] Build succeeds after removing DeactivateSceneIntent
- [ ] Verify "Deactivate Scene" no longer appears in Shortcuts.app
- [ ] Verify `set current scene to ""` is a no-op in AppleScript

🤖 Generated with [Claude Code](https://claude.com/claude-code)