### PR TITLE
Update token creation help text with bullet points

### DIFF
--- a/BusyLight/BusyLight.help/Contents/Resources/en.lproj/getting-started.html
+++ b/BusyLight/BusyLight.help/Contents/Resources/en.lproj/getting-started.html
@@ -30,6 +30,7 @@
     <ol>
         <li>Open your Home Assistant web interface.</li>
         <li>Click your profile icon in the bottom-left corner of the sidebar.</li>
+        <li>Click on the <strong>Security</strong> tab.</li>
         <li>Scroll down to the <strong>Long-Lived Access Tokens</strong>
             section.</li>
         <li>Click <strong>Create Token</strong>, give it a name (e.g.

--- a/BusyLight/Views/Settings/HomeAssistantTab.swift
+++ b/BusyLight/Views/Settings/HomeAssistantTab.swift
@@ -31,7 +31,14 @@ struct HomeAssistantTab: View {
                         settings.haToken = newValue
                     }
 
-                Text("To create a Long-Lived Access Token, go to your Home Assistant instance, click on your profile (bottom left), scroll to the bottom, and click \"Create Token\".")
+                Text("""
+                    To create a Long-Lived Access Token:
+                    \u{2022} Go to your Home Assistant instance
+                    \u{2022} Click on your profile icon (bottom left)
+                    \u{2022} Click on the Security tab
+                    \u{2022} Scroll to the bottom
+                    \u{2022} Click "Create token"
+                    """)
                     .font(.caption)
                     .foregroundStyle(.secondary)
 

--- a/BusyLight/Views/Settings/HomeAssistantTab.swift
+++ b/BusyLight/Views/Settings/HomeAssistantTab.swift
@@ -33,11 +33,12 @@ struct HomeAssistantTab: View {
 
                 Text("""
                     To create a Long-Lived Access Token:
-                    \u{2022} Go to your Home Assistant instance
-                    \u{2022} Click on your profile icon (bottom left)
-                    \u{2022} Click on the Security tab
-                    \u{2022} Scroll to the bottom
-                    \u{2022} Click "Create token"
+                    1. Open your Home Assistant web interface.
+                    2. Click your profile icon in the bottom-left corner of the sidebar.
+                    3. Click on the Security tab.
+                    4. Scroll down to the Long-Lived Access Tokens section.
+                    5. Click Create Token, give it a name (e.g. "Busy Light"), and click OK.
+                    6. Copy the token immediately \u{2014} it is only shown once.
                     """)
                     .font(.caption)
                     .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- Break dense single-sentence token instructions into a bulleted list in the HA settings tab
- Add missing "Security tab" step to both in-app help text and Help book
- Help book `getting-started.html` also updated for consistency

Closes #79

## Test plan
- [x] Build succeeds
- [ ] Visually verify the bulleted list renders correctly in the Settings > Home Assistant tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)