### PR TITLE
Fix Ko-fi button disappearing when window loses focus

### DIFF
--- a/BusyLight/Views/Settings/GeneralTab.swift
+++ b/BusyLight/Views/Settings/GeneralTab.swift
@@ -1,6 +1,21 @@
 import SwiftUI
 import ServiceManagement
 
+/// A button style that always renders with a yellow fill, unaffected by
+/// the window's active state. The system `.borderedProminent` style becomes
+/// invisible in inactive windows; this keeps the Ko-fi button visible.
+private struct KofiButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.body.weight(.medium))
+            .foregroundStyle(.black)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(Color.yellow.opacity(configuration.isPressed ? 0.7 : 1.0))
+            .clipShape(.rect(cornerRadius: 6))
+    }
+}
+
 struct GeneralTab: View {
     @State private var settings = AppSettings.shared
     @State private var launchAtLogin = false
@@ -64,9 +79,8 @@ struct GeneralTab: View {
                 } label: {
                     Label("Buy Me a Coffee", systemImage: "heart.fill")
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(KofiButtonStyle())
                 .help(Text("Support Busy Light on Ko-fi"))
-                .tint(.yellow)
             }
             .padding()
         }

--- a/BusyLight/Views/Settings/GeneralTab.swift
+++ b/BusyLight/Views/Settings/GeneralTab.swift
@@ -59,7 +59,9 @@ struct GeneralTab: View {
 
                 Spacer()
 
-                Link(destination: URL(string: "https://ko-fi.com/swizzlevixen")!) {
+                Button {
+                    NSWorkspace.shared.open(URL(string: "https://ko-fi.com/swizzlevixen")!)
+                } label: {
                     Label("Buy Me a Coffee", systemImage: "heart.fill")
                 }
                 .buttonStyle(.borderedProminent)


### PR DESCRIPTION
## Summary
- Replace `Link` with `Button` + `NSWorkspace.shared.open()` for the Ko-fi donate button
- `Link` with `.borderedProminent` and `.tint(.yellow)` becomes invisible when the Settings window is inactive
- All styling (prominent yellow, heart icon, help tooltip) is preserved

Closes #81

## Test plan
- [ ] Open Settings > General
- [ ] Click away from the Settings window
- [ ] Verify the yellow "Buy Me a Coffee" button remains visible
- [ ] Click the button — verify it opens https://ko-fi.com/swizzlevixen

🤖 Generated with [Claude Code](https://claude.com/claude-code)