### PR TITLE
Add troubleshooting page to Help book

### DIFF
--- a/BusyLight/BusyLight.help/Contents/Resources/en.lproj/index.html
+++ b/BusyLight/BusyLight.help/Contents/Resources/en.lproj/index.html
@@ -25,6 +25,8 @@
             &mdash; choose which scenes appear in the menu bar</li>
         <li><a href="using-triggers.html">Using Triggers</a>
             &mdash; automatically activate scenes based on system events</li>
+        <li><a href="troubleshooting.html">Troubleshooting</a>
+            &mdash; solutions for common issues</li>
     </ul>
 </body>
 </html>

--- a/BusyLight/BusyLight.help/Contents/Resources/en.lproj/troubleshooting.html
+++ b/BusyLight/BusyLight.help/Contents/Resources/en.lproj/troubleshooting.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="color-scheme" content="light dark">
+    <meta name="AppleTitle" content="Busy Light Help">
+    <meta name="description" content="Troubleshooting common issues with Busy Light.">
+    <title>Troubleshooting</title>
+    <link rel="stylesheet" href="../shared/style.css">
+</head>
+<body>
+    <a name="troubleshooting"></a>
+    <div class="breadcrumb"><a href="index.html">Busy Light Help</a></div>
+    <h1>Troubleshooting</h1>
+
+    <h2>Cannot connect to Home Assistant</h2>
+    <ul>
+        <li>Make sure your Home Assistant URL is correct and includes the port
+            number if needed (e.g. <code>http://homeassistant.local:8123</code>).</li>
+        <li>Verify that your Mac can reach the Home Assistant server. Try
+            opening the URL in a web browser.</li>
+        <li>If you use HTTPS, ensure your certificate is valid or trusted by
+            your Mac.</li>
+        <li>Check that your firewall or network settings allow connections on
+            the Home Assistant port.</li>
+    </ul>
+
+    <h2>Token not recognized or authentication errors</h2>
+    <ul>
+        <li>Make sure you copied the entire token with no extra spaces or
+            line breaks.</li>
+        <li>Long-lived access tokens can expire if they are revoked in Home
+            Assistant. Create a new token and paste it into the Token field.</li>
+        <li>Verify the token belongs to a user with permission to activate
+            scenes.</li>
+    </ul>
+    <div class="note">
+        Your token is stored in the macOS Keychain. If you are prompted to
+        unlock the Keychain, allow access so Busy Light can retrieve the
+        token on launch.
+    </div>
+
+    <h2>Scenes not appearing in the list</h2>
+    <ul>
+        <li>Scenes must be configured in Home Assistant before they appear in
+            Busy Light. Check your HA dashboard to confirm they exist.</li>
+        <li>The scene list is fetched when you open the Scenes tab. Make sure
+            your connection is working first (a green checkmark on the Home
+            Assistant tab).</li>
+        <li>Only entities whose ID starts with <code>scene.</code> are
+            shown.</li>
+    </ul>
+
+    <h2>Triggers not firing</h2>
+    <ul>
+        <li>Open <strong>Settings &gt; Triggers</strong> and confirm that the
+            trigger toggle is turned on and a scene is selected.</li>
+        <li>The webcam trigger takes priority over the microphone trigger. If
+            both fire at the same time, only the webcam scene is used.</li>
+        <li>Focus Mode detection is experimental and reads from a system file
+            that may change between macOS versions. If it stops working after
+            a macOS update, it will degrade gracefully.</li>
+    </ul>
+
+    <h2>Camera or microphone not detected</h2>
+    <p>
+        Busy Light does <strong>not</strong> need camera or microphone
+        permissions. It reads device metadata (whether the device is in use)
+        rather than accessing the actual audio or video stream.
+    </p>
+    <ul>
+        <li>Some virtual cameras (e.g. software-only camera drivers) may not
+            report their status through the system APIs that Busy Light
+            monitors.</li>
+        <li>If detection stops working, try quitting and relaunching Busy
+            Light.</li>
+    </ul>
+
+    <h2>Resetting the app</h2>
+    <p>
+        To reset Busy Light to its first-run state, open Terminal and run:
+    </p>
+    <p><code>defaults delete com.mboszko.BusyLight</code></p>
+    <p>
+        This removes all preferences including scenes, triggers, and display
+        settings. Your Home Assistant token is stored separately in the
+        Keychain and is not affected by this command.
+    </p>
+
+</body>
+</html>

--- a/BusyLight/BusyLightApp.swift
+++ b/BusyLight/BusyLightApp.swift
@@ -35,6 +35,9 @@ struct BusyLightApp: App {
                 Button("Using Triggers") {
                     HelpManager.openHelp(anchor: "using-triggers")
                 }
+                Button("Troubleshooting") {
+                    HelpManager.openHelp(anchor: "troubleshooting")
+                }
             }
         }
     }

--- a/BusyLight/Services/HelpManager.swift
+++ b/BusyLight/Services/HelpManager.swift
@@ -11,6 +11,7 @@ enum HelpManager {
     /// - `"getting-started"` — Getting Started
     /// - `"adding-scenes"` — Adding Scenes
     /// - `"using-triggers"` — Using Triggers
+    /// - `"troubleshooting"` — Troubleshooting
     @MainActor static func openHelp(anchor: String = "busylight-help") {
         NSHelpManager.shared.openHelpAnchor(
             anchor as NSHelpManager.AnchorName,

--- a/BusyLight/Views/MenuBar/MenuBarContentView.swift
+++ b/BusyLight/Views/MenuBar/MenuBarContentView.swift
@@ -87,6 +87,9 @@ struct MenuBarContentView: View {
             Button { HelpManager.openHelp(anchor: "using-triggers") } label: {
                 Label("Using Triggers", systemImage: "bolt.fill")
             }
+            Button { HelpManager.openHelp(anchor: "troubleshooting") } label: {
+                Label("Troubleshooting", systemImage: "wrench.and.screwdriver")
+            }
         } label: {
             Label("Help", systemImage: "questionmark.circle")
         }


### PR DESCRIPTION
## Summary
- Add new `troubleshooting.html` Help book page covering:
  - Cannot connect to Home Assistant
  - Token not recognized / authentication errors
  - Scenes not appearing in the list
  - Triggers not firing
  - Camera or microphone not detected
  - Resetting the app
- Link from Help book index page

Closes #74

## Test plan
- [x] Build succeeds
- [ ] Open Help menu > Busy Light Help > verify Troubleshooting link appears
- [ ] Click through to Troubleshooting page, verify content and formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)