### PR TITLE
Fix troubleshooting help page not reachable from menus

### DIFF
--- a/BusyLight/BusyLight.help/Contents/Info.plist
+++ b/BusyLight/BusyLight.help/Contents/Info.plist
@@ -18,7 +18,7 @@
 	<key>CFBundleSignature</key>
 	<string>hbwr</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>HPDBookAccessPath</key>
 	<string>index.html</string>
 	<key>HPDBookIndexPath</key>

--- a/BusyLight/Info.plist
+++ b/BusyLight/Info.plist
@@ -21,11 +21,11 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0</string>
+	<string>1.0.1</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>260413.1148</string>
 	<key>GitShortSHA</key>
-	<string></string>
+	<string>bb37660</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/project.yml
+++ b/project.yml
@@ -42,6 +42,8 @@ targets:
     postBuildScripts:
       - name: "Generate Help Index"
         script: |
+          HELP_PLIST="$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/BusyLight.help/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $(date +%y%m%d.%H%M)" "$HELP_PLIST"
           hiutil -I corespotlight -Caf "$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/BusyLight.help/Contents/Resources/en.lproj/search.helpindex" "$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/BusyLight.help/Contents/Resources/en.lproj/"
         basedOnDependencyAnalysis: false
     settings:

--- a/project.yml
+++ b/project.yml
@@ -38,12 +38,19 @@ targets:
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $(date +%y%m%d.%H%M)" "$PLIST"
           GIT_SHA=$(git -C "${PROJECT_DIR}" rev-parse --short HEAD 2>/dev/null || echo "unknown")
           /usr/libexec/PlistBuddy -c "Set :GitShortSHA ${GIT_SHA}" "$PLIST" 2>/dev/null || /usr/libexec/PlistBuddy -c "Add :GitShortSHA string ${GIT_SHA}" "$PLIST"
+          GIT_TAG=$(git -C "${PROJECT_DIR}" describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$GIT_TAG" ]; then
+            MARKETING_VERSION="${GIT_TAG#v}"
+            /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${MARKETING_VERSION}" "$PLIST"
+          fi
         basedOnDependencyAnalysis: false
     postBuildScripts:
       - name: "Generate Help Index"
         script: |
           HELP_PLIST="$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/BusyLight.help/Contents/Info.plist"
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $(date +%y%m%d.%H%M)" "$HELP_PLIST"
+          APP_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "${PROJECT_DIR}/BusyLight/Info.plist" 2>/dev/null || echo "1.0")
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${APP_VERSION}" "$HELP_PLIST"
           hiutil -I corespotlight -Caf "$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/BusyLight.help/Contents/Resources/en.lproj/search.helpindex" "$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/BusyLight.help/Contents/Resources/en.lproj/"
         basedOnDependencyAnalysis: false
     settings:


### PR DESCRIPTION
Fixes #86

## Summary

The troubleshooting help page wasn't reachable from menus because macOS caches help books keyed by the app's `CFBundleShortVersionString`. Two problems:

1. **Help bundle version never bumped** — the help bundle `CFBundleVersion` stayed at `1` after adding the troubleshooting page, but this turned out to not matter because...
2. **App marketing version was hardcoded** — `CFBundleShortVersionString` was `1.0.0` in `Info.plist` and the build script never updated it from git tags. The help cache at `~/Library/Group Containers/group.com.apple.helpviewer.content/` was keyed on `*1.0.0` and still contained the old help book without `troubleshooting.html`.

### Changes

- **Pre-build script**: derive `CFBundleShortVersionString` from the latest git tag (strip `v` prefix), so tagging a release automatically updates the app version
- **Post-build script**: sync the help bundle's `CFBundleShortVersionString` with the app version and auto-stamp `CFBundleVersion` with a build timestamp
- Bump help bundle `CFBundleVersion` from `1` to `2` as a baseline

## Test plan

- [ ] Build and run — app should report version 1.0.1 (from git tag)
- [ ] Help > Troubleshooting from main menu — should open troubleshooting page
- [ ] Menu bar > Help > Troubleshooting — should open troubleshooting page
- [ ] Verify other help pages still work from menus
- [ ] Tag a new version (e.g. `v1.0.2`), rebuild — app should report 1.0.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)